### PR TITLE
feat(email): add customer BCC configuration and improve email templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - Do not change visible design or page text without explicit user permission
 - Do not remove homepage SVG assets; they are part of the approved design
 - Use the homepage enquiry form success message styling for all new or updated success messages: `alert alert-success w-full items-start text-sm` with the same check-circle icon and compact text layout, unless the user explicitly asks for a different design
+- Use "We"/"we'll" wording in all new or updated public-facing website copy, not "I"/"I'll"
 - Cookie consent UI must appear immediately on initial page load; do not defer or delay the banner for performance optimization
 
 ## React Best Practices

--- a/app/admin/email-test/EmailTestPageClient.tsx
+++ b/app/admin/email-test/EmailTestPageClient.tsx
@@ -175,7 +175,10 @@ const requestOptions: EmailRequestOption[] = [
   {
     id: 'contact-enquiry',
     label: 'Contact page enquiry',
-    scenarios: createScenarioOptions('contact-admin-inquiry', 'Admin')
+    scenarios: [
+      ...createScenarioOptions('contact-admin-inquiry', 'Admin'),
+      ...createScenarioOptions('contact-customer-confirmation', 'Customer')
+    ]
   },
   {
     id: 'homepage-custom-cake-enquiry',
@@ -337,6 +340,16 @@ const templateFieldMap: Record<EmailTemplateId, EditableFieldKey[]> = {
     'referrer',
     'giftNote',
     'attachmentNames'
+  ],
+  'contact-customer-confirmation': [
+    ...commonFields,
+    'address',
+    'city',
+    'postcode',
+    'cakeInterest',
+    'dateNeeded',
+    'giftNote',
+    ...listFields
   ],
   'contact-inline-order-customer': [
     ...commonFields,

--- a/app/api/contact/__tests__/route.test.ts
+++ b/app/api/contact/__tests__/route.test.ts
@@ -288,8 +288,16 @@ describe('/api/contact', () => {
         referrer: null,
         attachment_names: null
       })
-      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend).toHaveBeenCalledTimes(2)
       expect(mockSend.mock.calls[0]?.[0]?.html).not.toContain('>Phone<')
+      const customerEmailPayload = mockSend.mock.calls.find((call) => call[0].to === 'john@example.com')?.[0]
+      expect(customerEmailPayload).toEqual(expect.objectContaining({
+        replyTo: 'hello@olgishcakes.co.uk',
+        subject: 'We have received your message'
+      }))
+      expect(customerEmailPayload?.text).toContain('Thank you, we\'ve received your message')
+      expect(customerEmailPayload?.text).toContain('Test message with enough characters')
+      expect(customerEmailPayload?.text).toContain('Questions about your enquiry?')
       expect(mockSendTelegramManagerNotification).toHaveBeenCalledWith(expect.objectContaining({
         type: 'contact-enquiry',
         customerName: 'John',
@@ -317,7 +325,7 @@ describe('/api/contact', () => {
       expect(json).toEqual({ success: true })
       expect(mockGetSupabaseAdminClient).not.toHaveBeenCalled()
       expect(mockSupabaseInsert).not.toHaveBeenCalled()
-      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend).toHaveBeenCalledTimes(2)
       expect(mockSendTelegramManagerNotification).not.toHaveBeenCalled()
     })
 
@@ -564,7 +572,7 @@ describe('/api/contact', () => {
       const response = await POST(request)
       const adminEmailCall = mockSend.mock.calls[0]?.[0]
 
-      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend).toHaveBeenCalledTimes(2)
       expect(response.status).toBe(200)
       expect(adminEmailCall?.subject).toContain('New Contact: John Doe')
       expect(adminEmailCall?.text).toContain('- Date needed:')
@@ -573,6 +581,21 @@ describe('/api/contact', () => {
       expect(adminEmailCall?.text).toContain('- Additional note: Please call after 6pm')
       expect(adminEmailCall?.text).toContain('- Gift note: Happy birthday!')
       expect(adminEmailCall?.text).toContain('- Attachments: contact-design.jpg')
+      const customerEmailCall = mockSend.mock.calls.find((call) => call[0].to === 'john@example.com')?.[0]
+      expect(customerEmailCall?.subject).toBe('We have received your message')
+      expect(customerEmailCall?.text).toContain('- Name: John Doe')
+      expect(customerEmailCall?.text).toContain('- Email: john@example.com')
+      expect(customerEmailCall?.text).toContain('- Phone: 07123456789')
+      expect(customerEmailCall?.text).toContain('- Address: 42 Baker Street')
+      expect(customerEmailCall?.text).toContain('- City: London')
+      expect(customerEmailCall?.text).toContain('- Postcode: NW1 6XE')
+      expect(customerEmailCall?.text).toContain('- Topic: Honey cake')
+      expect(customerEmailCall?.text).toContain('- Date: 12 March 2026')
+      expect(customerEmailCall?.text).toContain('- Message: I need a quote for a celebration cake')
+      expect(customerEmailCall?.text).toContain('- Additional note: Please call after 6pm')
+      expect(customerEmailCall?.text).toContain('- Gift note: Happy birthday!')
+      expect(customerEmailCall?.text).not.toContain('Referrer')
+      expect(customerEmailCall?.text).toContain('- Attachments: contact-design.jpg')
       expect(adminEmailCall?.html).toContain('Date needed')
       expect(adminEmailCall?.html).toContain('Cake interest')
       expect(adminEmailCall?.html).toContain('Submitted message')
@@ -680,8 +703,10 @@ describe('/api/contact', () => {
       expect(customerEmailCall?.text).toContain('Thank you. We\'ve received your cake request and will review the details within 24 hours.')
       expect(customerEmailCall?.text).toContain('Date needed: 15 March 2026')
       expect(customerEmailCall?.text).toContain('Estimated price: £25')
+      expect(customerEmailCall?.text).toContain('Occasion: Birthday')
       expect(customerEmailCall?.text).toContain('Serves 8-12 people')
-      expect(customerEmailCall?.text).toContain('I\'ll confirm availability, final price, and any design details before you need to pay.')
+      expect(customerEmailCall?.text).toContain('We\'ll confirm availability, final price, and any design details before you need to pay.')
+      expect(customerEmailCall?.text).not.toContain('I\'ll')
       expect(customerEmailCall?.text).toContain('Nothing is booked or payable until we agree the design, price, and collection or delivery details.')
       expect(customerEmailCall?.text).not.toContain('Order Confirmation')
 
@@ -712,6 +737,62 @@ describe('/api/contact', () => {
         emailAttemptedAt: expect.any(String)
       }))
     })
+
+    it('should hide generated product summary when customer message is empty', async () => {
+      const generatedSummary = [
+        'Product: Vintage Red Velvet Cake',
+        'Product type: cake',
+        'Design type: standard',
+        'Filling: Red Velvet',
+        'Serves 8-12 people',
+        'Price: \u00A338'
+      ].join('\n')
+      const formData = new FormData()
+      formData.append('name', 'Jane')
+      formData.append('email', 'jane@example.com')
+      formData.append('phone', '07123456789')
+      formData.append('address', '10 High Street')
+      formData.append('city', 'Leeds')
+      formData.append('postcode', 'LS1 1AA')
+      formData.append('dateNeeded', '2026-07-08')
+      formData.append('message', generatedSummary)
+      formData.append('isOrderForm', 'true')
+      formData.append('productType', 'cake')
+      formData.append('productId', 'vintage-red-velvet-cake')
+      formData.append('productName', 'Vintage Red Velvet Cake')
+      formData.append('totalPrice', '38')
+      formData.append('requestMode', 'browse-catalog')
+      formData.append('designType', 'standard')
+      formData.append('occasion', 'anniversary')
+      formData.append('filling', 'Red Velvet')
+      formData.append('servings', 'Serves 8-12 people')
+
+      const request = createRequest(formData)
+
+      const response = await POST(request)
+
+      const customerEmailCall = mockSend.mock.calls.find((call) => call[0].to === 'jane@example.com')?.[0]
+
+      expect(response.status).toBe(200)
+      expect(mockCreateFromMock).toHaveBeenCalledWith(expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            specialInstructions: ''
+          })
+        ],
+        metadata: expect.objectContaining({
+          inlineOrderContext: expect.not.objectContaining({
+            customerMessage: expect.any(String)
+          })
+        })
+      }))
+      expect(customerEmailCall?.html).not.toContain('Customer message')
+      expect(customerEmailCall?.text).not.toContain('Customer message')
+      expect(customerEmailCall?.html).not.toContain('Product type: cake')
+      expect(customerEmailCall?.text).not.toContain('Product type: cake')
+      expect(customerEmailCall?.text).not.toContain('Price: \u00A338')
+    })
+
     it('should accept legacy order page payload with custom product type and normalize custom design order type', async () => {
       const formData = new FormData()
       formData.append('name', 'John')
@@ -735,13 +816,15 @@ describe('/api/contact', () => {
           orderType: 'custom-cake',
           metadata: expect.objectContaining({
             inlineOrderContext: expect.objectContaining({
-              sourceOrderType: 'custom-design'
+              sourceOrderType: 'custom-design',
+              customerMessage: 'Legacy order flow message with enough details'
             })
           }),
           items: [
             expect.objectContaining({
               productType: 'cake',
-              productName: 'Custom Order'
+              productName: 'Custom Order',
+              specialInstructions: 'Legacy order flow message with enough details'
             })
           ]
         })
@@ -771,13 +854,15 @@ describe('/api/contact', () => {
           orderType: 'custom-cake',
           metadata: expect.objectContaining({
             inlineOrderContext: expect.objectContaining({
-              sourceOrderType: 'browse-catalog'
+              sourceOrderType: 'browse-catalog',
+              customerMessage: 'Legacy order flow message with enough details'
             })
           }),
           items: [
             expect.objectContaining({
               productType: 'cake',
-              productName: 'Custom Order'
+              productName: 'Custom Order',
+              specialInstructions: 'Legacy order flow message with enough details'
             })
           ]
         })
@@ -790,6 +875,7 @@ describe('/api/contact', () => {
       formData.append('email', 'john@example.com')
       formData.append('phone', '07123456789')
       formData.append('message', 'Please call before delivery')
+      formData.append('customerMessage', 'Please call before delivery')
       formData.append('isOrderForm', 'true')
       formData.append('productType', 'cake')
       formData.append('productId', 'honey-cake')
@@ -918,8 +1004,10 @@ describe('/api/contact', () => {
       const request = createRequest(formData)
 
       const response = await POST(request)
+      const json = await response.json()
 
       expect(response.status).toBe(200)
+      expect(json).toEqual({ success: true })
       expect(mockSupabaseInsert).toHaveBeenCalledTimes(1)
     })
 
@@ -935,10 +1023,36 @@ describe('/api/contact', () => {
       const request = createRequest(formData)
 
       const response = await POST(request)
+      const json = await response.json()
 
       expect(response.status).toBe(200)
+      expect(json).toEqual({ success: true })
       expect(mockSupabaseInsert).toHaveBeenCalledTimes(1)
       expect(mockSend).not.toHaveBeenCalled()
+    })
+
+    it('should still return 200 when only the customer confirmation email fails', async () => {
+      mockSend
+        .mockResolvedValueOnce({ data: { id: 'admin-email-id' }, error: null })
+        .mockResolvedValueOnce({ error: { message: 'Customer confirmation failed' } })
+
+      const formData = new FormData()
+      formData.append('name', 'John')
+      formData.append('email', 'john@example.com')
+      formData.append('phone', '07123456789')
+      formData.append('message', 'Test message with enough characters')
+
+      const request = createRequest(formData)
+
+      const response = await POST(request)
+      const json = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(json).toEqual({ success: true })
+      expect(mockSupabaseInsert).toHaveBeenCalledTimes(1)
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      expect(mockSend.mock.calls[0]?.[0]?.to).toBe('hello@olgishcakes.co.uk')
+      expect(mockSend.mock.calls[1]?.[0]?.to).toBe('john@example.com')
     })
 
     it('should still send the contact email when saving a general contact enquiry to Supabase fails', async () => {
@@ -964,7 +1078,7 @@ describe('/api/contact', () => {
       expect(response.status).toBe(200)
       expect(json).toEqual({ success: true })
       expect(mockSupabaseInsert).toHaveBeenCalledTimes(1)
-      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend).toHaveBeenCalledTimes(2)
     })
 
     it('should return 500 when a general contact enquiry is neither persisted nor emailed', async () => {
@@ -985,7 +1099,7 @@ describe('/api/contact', () => {
       expect(response.status).toBe(500)
       expect(json).toEqual({ error: 'Failed to send email' })
       expect(mockGetSupabaseAdminClient).not.toHaveBeenCalled()
-      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend).toHaveBeenCalledTimes(2)
     })
 
     it('should return 500 when both Supabase persistence and contact email fail', async () => {
@@ -1012,7 +1126,7 @@ describe('/api/contact', () => {
       expect(response.status).toBe(500)
       expect(json).toEqual({ error: 'Failed to send email' })
       expect(mockSupabaseInsert).toHaveBeenCalledTimes(1)
-      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(mockSend).toHaveBeenCalledTimes(2)
     })
 
     it('should mark inline order emails as unsent when transport does not accept delivery', async () => {
@@ -1084,7 +1198,8 @@ describe('/api/contact', () => {
       expect(fallbackCustomerEmailCall?.text).toContain('Thank you. We\'ve received your cake request and will review the details within 24 hours.')
       expect(fallbackCustomerEmailCall?.text).toContain('Date needed: 20 March 2026')
       expect(fallbackCustomerEmailCall?.text).toContain('Estimated price: £25')
-      expect(fallbackCustomerEmailCall?.text).toContain('I\'ll confirm availability, final price, and any design details before you need to pay.')
+      expect(fallbackCustomerEmailCall?.text).toContain('We\'ll confirm availability, final price, and any design details before you need to pay.')
+      expect(fallbackCustomerEmailCall?.text).not.toContain('I\'ll')
       expect(fallbackCustomerEmailCall?.text).not.toContain('Order Confirmation')
       expect(fallbackAdminEmailCall?.html).toContain('Date needed')
       expect(fallbackAdminEmailCall?.text).toContain('- Date needed:')
@@ -1092,7 +1207,7 @@ describe('/api/contact', () => {
       expect(fallbackAdminEmailCall?.text).toContain('- Quantity: 1')
       expect(fallbackAdminEmailCall?.text).toContain('- Delivery method: collection')
       expect(fallbackAdminEmailCall?.text).toContain('- Delivery address: 12 Queen Road, Manchester, M1 1AA')
-      expect(fallbackAdminEmailCall?.text).toContain('- Occasion: wedding')
+      expect(fallbackAdminEmailCall?.text).toContain('- Occasion: Wedding')
       expect(fallbackAdminEmailCall?.text).toContain('- Design type: Individual design')
       expect(fallbackAdminEmailCall?.text).toContain('- Filling: Vanilla cream')
       expect(fallbackAdminEmailCall?.text).toContain('- Servings: Serves 20')

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -4,6 +4,7 @@ import { generateOrderNumber, generateUniqueKey } from '@/lib/order-utils'
 import { withRateLimit } from '@/lib/rate-limit'
 import { formatRequestIpLocation, getRequestIpLocation } from '@/lib/request-location'
 import { validateCsrfToken } from '@/lib/csrf'
+import { getCustomerEmailBcc } from '@/lib/email/customer-bcc'
 import { BUSINESS_CONSTANTS } from '@/lib/constants'
 import { getEmailTransportMode, requiresLiveEmailConfiguration, sendEmail } from '@/lib/email/service'
 import { readRequiredFormData } from '@/lib/form-request'
@@ -78,11 +79,7 @@ function resolveInlineOrderProductType(value: string): InlineOrderProductType | 
 
 function getCustomerOrderEmailBcc(): string | undefined {
   const configuredBcc = process.env.ORDER_EMAIL_BCC?.trim() || process.env.ADMIN_BCC_EMAIL?.trim()
-  if (!configuredBcc || configuredBcc.length === 0) {
-    return undefined
-  }
-
-  return configuredBcc
+  return getCustomerEmailBcc(configuredBcc)
 }
 
 function isInlineOrderRequestMode(value: string): value is InlineOrderRequestMode {
@@ -150,11 +147,72 @@ function normalizeDesignTypeLabel(designType: InlineOrderDesignType): string {
   return designType === 'individual' ? 'Individual design' : 'Standard design'
 }
 
+function normalizeDisplayLabel(value: string): string {
+  const trimmedValue = value.trim()
+  if (trimmedValue.length === 0 || /[A-Z]/.test(trimmedValue)) {
+    return trimmedValue
+  }
+
+  return trimmedValue
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b[a-z]/g, (letter) => letter.toUpperCase())
+}
+
+function isGeneratedProductSummary(value: string | undefined): boolean {
+  const normalizedValue = value?.trim().toLowerCase() || ''
+
+  return normalizedValue.includes('product:') &&
+    normalizedValue.includes('product type:') &&
+    normalizedValue.includes('price:')
+}
+
+function extractExplicitCustomerMessage(value: string | undefined): string | undefined {
+  const lines = value?.split(/\r?\n/) || []
+  const messageLine = lines.find((line) => {
+    const normalizedLine = line.trim().toLowerCase()
+    return normalizedLine.startsWith('message:') ||
+      normalizedLine.startsWith('customer message:') ||
+      normalizedLine.startsWith('requirements:')
+  })
+
+  if (!messageLine) {
+    return undefined
+  }
+
+  return messageLine.replace(/^(message|customer message|requirements):\s*/i, '').trim() || undefined
+}
+
+function resolveInlineCustomerMessage(...values: string[]): string {
+  for (const value of values) {
+    const explicitMessage = extractExplicitCustomerMessage(value)
+    if (explicitMessage) {
+      const resolvedExplicitMessage = resolveInlineCustomerMessage(explicitMessage)
+      if (resolvedExplicitMessage.length > 0) {
+        return resolvedExplicitMessage
+      }
+    }
+
+    const trimmedValue = value.trim()
+    const normalizedValue = trimmedValue.toLowerCase()
+
+    if (
+      trimmedValue.length > 0 &&
+      normalizedValue !== 'message' &&
+      normalizedValue !== 'test message' &&
+      !isGeneratedProductSummary(trimmedValue)
+    ) {
+      return trimmedValue
+    }
+  }
+
+  return ''
+}
+
 const cakeRequestIntro = 'Thank you. We\'ve received your cake request and will review the details within 24 hours.'
 const cakeRequestPriceLabel = 'Estimated price'
 const cakeRequestNextSteps = [
-  'I\'ll review your requested date, cake details, and any design notes within 24 hours.',
-  'I\'ll confirm availability, final price, and any design details before you need to pay.',
+  'We\'ll review your requested date, cake details, and any design notes within 24 hours.',
+  'We\'ll confirm availability, final price, and any design details before you need to pay.',
   'Nothing is booked or payable until we agree the design, price, and collection or delivery details.'
 ]
 
@@ -526,6 +584,28 @@ async function handlePOST(request: NextRequest) {
     if (!isOrderInquiry) {
       let enquiryPersisted = false
       let adminEmailAccepted = false
+      let customerEmailAccepted = false
+      const contactEmailInput = {
+        customerName: name,
+        customerEmail: email,
+        customerPhone: normalizedPhone,
+        orderType: 'custom-cake-enquiry',
+        address: address || undefined,
+        city: city || undefined,
+        postcode: postcode || undefined,
+        dateNeeded: dateNeeded || undefined,
+        cakeInterest: cakeInterest || undefined,
+        customerMessage: message || undefined,
+        message: message || undefined,
+        note: note || undefined,
+        giftNote: giftNote || undefined,
+        referrer: referrer || undefined,
+        attachmentNames: designImage ? [designImage.name] : [],
+        nextSteps: [
+          'We\'ll read your message and check the details you sent.',
+          'We\'ll reply with the next practical step as soon as we can.'
+        ]
+      }
 
       try {
         enquiryPersisted = await saveContactEnquiry({
@@ -569,19 +649,8 @@ async function handlePOST(request: NextRequest) {
         const adminEmailResult = await sendEmail({
           templateId: 'contact-admin-inquiry',
           input: {
-            customerName: name,
-            customerEmail: email,
-            customerPhone: normalizedPhone,
-            address: address || undefined,
-            city: city || undefined,
-            postcode: postcode || undefined,
-            dateNeeded: dateNeeded || undefined,
-            cakeInterest: cakeInterest || undefined,
-            message: message || undefined,
-            note: note || undefined,
-            giftNote: giftNote || undefined,
-            referrer: referrer || undefined,
-            attachmentNames: designImage ? [designImage.name] : [],
+            ...contactEmailInput,
+            orderType: undefined,
             titleOverride: `New Contact: ${name}`
           },
           modeOverride: emailMode,
@@ -607,7 +676,34 @@ async function handlePOST(request: NextRequest) {
 
         adminEmailAccepted = true
       } catch (emailError) {
-        logger.error('Contact enquiry email failed after persistence', {
+        logger.error('Contact enquiry admin email failed after persistence', {
+          emailError,
+          customerEmail: email,
+          referrer: referrer || null
+        })
+      }
+
+      try {
+        const customerEmailResult = await sendEmail({
+          templateId: 'contact-customer-confirmation',
+          input: contactEmailInput,
+          modeOverride: emailMode,
+          message: {
+            from: 'Olgish Cakes <hello@olgishcakes.co.uk>',
+            to: email,
+            bcc: getCustomerEmailBcc(process.env.ADMIN_BCC_EMAIL),
+            replyTo: recipientEmail,
+            attachments: []
+          }
+        })
+
+        if (!customerEmailResult.accepted || customerEmailResult.error) {
+          throw new Error(customerEmailResult.error?.message || 'Transport did not accept customer email')
+        }
+
+        customerEmailAccepted = true
+      } catch (emailError) {
+        logger.error('Contact enquiry customer email failed after persistence', {
           emailError,
           customerEmail: email,
           referrer: referrer || null
@@ -615,11 +711,19 @@ async function handlePOST(request: NextRequest) {
       }
 
       if (!enquiryPersisted && !adminEmailAccepted) {
-        logger.error('Contact enquiry was not persisted or emailed', {
+        logger.error('Contact enquiry was not persisted or admin-emailed', {
           customerEmail: email,
           referrer: referrer || null
         })
         return NextResponse.json({ error: 'Failed to send email' }, { status: 500 })
+      }
+
+      if (!adminEmailAccepted) {
+        logger.error('Contact enquiry admin email delivery incomplete', {
+          customerEmailAccepted,
+          customerEmail: email,
+          referrer: referrer || null
+        })
       }
 
       return NextResponse.json({ success: true })
@@ -694,9 +798,7 @@ async function handlePOST(request: NextRequest) {
       const inferredDeliveryAddress = buildDeliveryAddress(address, city, postcode)
       const isCakesByPostOrder = resolvedProductType === 'gift-hamper'
       const designTypeLabel = normalizeDesignTypeLabel(designType)
-      const resolvedCustomerMessage = customerMessage.length > 0
-        ? customerMessage
-        : message
+      const resolvedCustomerMessage = resolveInlineCustomerMessage(customerMessage, message)
 
       const orderNumber = generateOrderNumber()
       let attachmentImages: OrderMessageAttachment[] = []
@@ -825,7 +927,7 @@ async function handlePOST(request: NextRequest) {
           totalPrice: totalPrice || 0,
           priceLabel: isCakesByPostOrder ? undefined : cakeRequestPriceLabel,
           dateNeeded: dateNeeded || undefined,
-          occasion: occasion || undefined,
+          occasion: normalizeDisplayLabel(occasion) || undefined,
           designType: designTypeLabel,
           filling: filling || undefined,
           servings: servings || undefined,
@@ -875,7 +977,7 @@ async function handlePOST(request: NextRequest) {
           unitPrice: totalPrice || 0,
           totalPrice: totalPrice || 0,
           dateNeeded: dateNeeded || undefined,
-          occasion: occasion || undefined,
+          occasion: normalizeDisplayLabel(occasion) || undefined,
           designType: designTypeLabel,
           filling: filling || undefined,
           servings: servings || undefined,
@@ -971,7 +1073,7 @@ async function handlePOST(request: NextRequest) {
           unitPrice: totalPrice || 0,
           totalPrice: totalPrice || 0,
           dateNeeded: dateNeeded || undefined,
-          occasion: occasion || undefined,
+          occasion: normalizeDisplayLabel(occasion) || undefined,
           designType: fallbackDesignTypeLabel,
           filling: filling || undefined,
           servings: servings || undefined,
@@ -1030,7 +1132,7 @@ async function handlePOST(request: NextRequest) {
           totalPrice: totalPrice || 0,
           priceLabel: isFallbackCakesByPostOrder ? undefined : cakeRequestPriceLabel,
           dateNeeded: dateNeeded || undefined,
-          occasion: occasion || undefined,
+          occasion: normalizeDisplayLabel(occasion) || undefined,
           designType: fallbackDesignTypeLabel,
           filling: filling || undefined,
           servings: servings || undefined,

--- a/app/api/custom-cake-enquiry/__tests__/route.test.ts
+++ b/app/api/custom-cake-enquiry/__tests__/route.test.ts
@@ -404,9 +404,11 @@ describe('/api/custom-cake-enquiry', () => {
         dateNeeded: '2026-12-25',
         occasion: 'Birthday',
         customerMessage: expect.stringContaining('Blue florals'),
-        nextSteps: expect.arrayContaining([
-          expect.stringContaining('availability')
-        ])
+        nextSteps: [
+          'We\'ll check the date, your notes and the delivery details.',
+          'We\'ll reply with availability, any questions, and a quote if we can make it for that date.',
+          'Nothing is booked or payable until we agree the design, price and collection or delivery details.'
+        ]
       })
     }))
   })
@@ -912,6 +914,15 @@ describe('/api/custom-cake-enquiry', () => {
         attachments: expect.arrayContaining([
           expect.objectContaining({ filename: 'reference.jpg' })
         ])
+      })
+    }))
+    expect(mockSendEmail).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      templateId: 'custom-cake-enquiry-customer',
+      input: expect.objectContaining({
+        attachmentNames: ['reference.jpg']
+      }),
+      message: expect.objectContaining({
+        attachments: []
       })
     }))
   })

--- a/app/api/custom-cake-enquiry/route.ts
+++ b/app/api/custom-cake-enquiry/route.ts
@@ -8,6 +8,7 @@ import {
   takeEnquiryRateLimit
 } from '@/lib/enquiry-rate-limit'
 import { getEmailTransportMode, requiresLiveEmailConfiguration, sendEmail } from '@/lib/email/service'
+import { getCustomerEmailBcc } from '@/lib/email/customer-bcc'
 import {
   createUnsupportedFormContentTypeResponse,
   isSupportedFormContentType,
@@ -695,8 +696,8 @@ export async function POST(request: NextRequest) {
           attachmentNames: referenceImage ? [referenceImage.name] : [],
           message: 'Date needed: ' + formattedDate,
           nextSteps: [
-            'I\'ll check the date, your notes and the delivery details.',
-            'I\'ll reply with availability, any questions, and a quote if I can make it for that date.',
+            'We\'ll check the date, your notes and the delivery details.',
+            'We\'ll reply with availability, any questions, and a quote if we can make it for that date.',
             'Nothing is booked or payable until we agree the design, price and collection or delivery details.'
           ]
         },
@@ -704,17 +705,9 @@ export async function POST(request: NextRequest) {
         message: {
           from: getEmailFromAddress(),
           to: formData.email,
-          bcc: process.env.ADMIN_BCC_EMAIL || undefined,
+          bcc: getCustomerEmailBcc(process.env.ADMIN_BCC_EMAIL),
           replyTo: recipientEmail,
-          attachments: referenceImage && attachmentBuffer
-            ? [
-                {
-                  filename: referenceImage.name,
-                  content: attachmentBuffer,
-                  contentType: referenceImage.type || undefined
-                }
-              ]
-            : []
+          attachments: []
         }
       })
 

--- a/app/api/dev/email-preview/__tests__/route.test.ts
+++ b/app/api/dev/email-preview/__tests__/route.test.ts
@@ -182,7 +182,7 @@ describe('/api/dev/email-preview', () => {
     expect(response.status).toBe(200)
     expect(json.input.deliveryCourier).toBe('evri')
     expect(json.input.statusMessage).toContain('Evri')
-    expect(json.rendered.text).toContain('Great news, your cakes by post order has been dispatched with Evri.')
+    expect(json.rendered.text).toContain('Great news, your cake by post order has been dispatched with Evri.')
     expect(json.rendered.text).toContain('Courier: Evri')
     expect(json.rendered.text).toContain('Evri will update the tracking as your parcel moves through their network.')
     expect(json.rendered.html).toContain('https://www.evri.com/track/parcel/H02X8A0022918652/details')

--- a/app/api/orders/[id]/__tests__/route.test.ts
+++ b/app/api/orders/[id]/__tests__/route.test.ts
@@ -279,11 +279,11 @@ describe('/api/orders/[id] PATCH', () => {
       headingOverride: 'Order request confirmed',
       titleOverride: 'Order Request Confirmed #26051220022842 - Olgish Cakes',
       statusMessage: 'Great news, we\'ve confirmed your cakes by post request.',
-      customerMessage: 'test message',
       giftNote: 'gift note test',
       deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
       paymentStatus: 'pending'
     })
+    expect(sendCall.input.customerMessage).toBeUndefined()
   })
 
   it('passes cakes by post status email fields for in-progress orders', async () => {
@@ -443,8 +443,524 @@ describe('/api/orders/[id] PATCH', () => {
       trackingNumber: 'H02X8A0022918652',
       headingOverride: 'Order dispatched',
       titleOverride: 'Order Dispatched #26051220022842 - Olgish Cakes',
-      statusMessage: 'Great news, your cakes by post order has been dispatched with Evri.'
+      statusMessage: 'Great news, your cake by post order has been dispatched with Evri.'
     })
+  })
+
+  it('uses cake wording for custom cake postal dispatch emails', async () => {
+    const currentOrder = {
+      _id: 'order-1',
+      _createdAt: '2026-05-12T18:00:00.000Z',
+      _updatedAt: '2026-05-12T18:00:00.000Z',
+      orderNumber: '26051220022842',
+      status: 'in-progress',
+      orderType: 'custom-cake',
+      customer: {
+        name: 'Igor Ieromenko',
+        email: 'igor@example.com',
+        phone: '07123456789',
+        address: '15 Allerton Grange Avenue',
+        city: 'Leeds',
+        postcode: 'LS17 6PR'
+      },
+      items: [
+        {
+          productName: 'Vintage Red Velvet Cake',
+          productId: 'vintage-red-velvet-cake',
+          productType: 'cake',
+          quantity: 1,
+          unitPrice: 38,
+          totalPrice: 38
+        }
+      ],
+      delivery: {
+        dateNeeded: '2026-07-08',
+        deliveryMethod: 'postal',
+        deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
+        trackingNumber: ''
+      },
+      pricing: {
+        total: 38,
+        paymentStatus: 'paid',
+        paymentMethod: 'card'
+      },
+      messages: [],
+      notes: [],
+      metadata: {}
+    }
+
+    mockGetSupabaseOrderByIdentifier.mockResolvedValueOnce(currentOrder)
+    mockUpdateSupabaseOrder.mockImplementation(async (order: typeof currentOrder) => ({
+      ...order,
+      _updatedAt: '2026-05-12T18:10:00.000Z'
+    }))
+
+    const request = new NextRequest('http://localhost/api/orders/order-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        status: 'out-delivery',
+        deliveryCourier: 'royal-mail',
+        trackingNumber: '12345'
+      })
+    })
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'order-1' }) })
+
+    expect(response.status).toBe(200)
+
+    const sendCall = mockSendEmail.mock.calls[0]?.[0]
+    expect(sendCall.input).toMatchObject({
+      status: 'out-for-delivery',
+      deliveryCourier: 'royal-mail',
+      trackingNumber: '12345',
+      headingOverride: 'Order out for delivery',
+      titleOverride: 'Order Out for Delivery #26051220022842 - Olgish Cakes',
+      statusMessage: 'Great news, your cake order has been dispatched with Royal Mail.'
+    })
+    expect(sendCall.input.statusMessage).not.toContain('cake by post order')
+  })
+
+  it('filters generated product summary from custom cake status customer message', async () => {
+    const generatedSummary = [
+      'Product: Vintage Red Velvet Cake',
+      'Product type: cake',
+      'Design type: standard',
+      'Filling: Red Velvet',
+      'Serves 8-12 people',
+      'Price: \u00A338'
+    ].join('\n')
+    const currentOrder = {
+      _id: 'order-1',
+      _createdAt: '2026-05-12T18:00:00.000Z',
+      _updatedAt: '2026-05-12T18:00:00.000Z',
+      orderNumber: '26060623195079',
+      status: 'in-progress',
+      orderType: 'custom-cake',
+      customer: {
+        name: 'Igor Ieromenko',
+        email: 'igor@example.com',
+        phone: '07123456789'
+      },
+      items: [
+        {
+          productName: 'Vintage Red Velvet Cake',
+          productId: 'vintage-red-velvet-cake',
+          productType: 'cake',
+          quantity: 1,
+          unitPrice: 38,
+          totalPrice: 38,
+          designType: 'standard',
+          size: 'Serves 8-12 people',
+          flavor: 'Red Velvet',
+          specialInstructions: generatedSummary
+        }
+      ],
+      delivery: {
+        dateNeeded: '2026-07-11',
+        deliveryMethod: 'local-delivery',
+        deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR'
+      },
+      pricing: {
+        total: 38,
+        paymentStatus: 'paid',
+        paymentMethod: 'card'
+      },
+      messages: [],
+      notes: [],
+      metadata: {}
+    }
+
+    mockGetSupabaseOrderByIdentifier.mockResolvedValueOnce(currentOrder)
+    mockUpdateSupabaseOrder.mockImplementation(async (order: typeof currentOrder) => ({
+      ...order,
+      _updatedAt: '2026-05-12T18:10:00.000Z'
+    }))
+
+    const request = new NextRequest('http://localhost/api/orders/order-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        status: 'out-delivery'
+      })
+    })
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'order-1' }) })
+
+    expect(response.status).toBe(200)
+
+    const sendCall = mockSendEmail.mock.calls[0]?.[0]
+    expect(sendCall.input.customerMessage).toBeUndefined()
+    expect(sendCall.input.statusMessage).toBe('Great news! Your order is out for local delivery and will be with you soon.')
+  })
+
+  it('uses metadata customer message when item special instructions are empty', async () => {
+    const currentOrder = {
+      _id: 'order-1',
+      _createdAt: '2026-05-12T18:00:00.000Z',
+      _updatedAt: '2026-05-12T18:00:00.000Z',
+      orderNumber: '26060623195079',
+      status: 'in-progress',
+      orderType: 'custom-cake',
+      customer: {
+        name: 'Igor Ieromenko',
+        email: 'igor@example.com',
+        phone: '07123456789'
+      },
+      items: [
+        {
+          productName: 'Vintage Red Velvet Cake',
+          productId: 'vintage-red-velvet-cake',
+          productType: 'cake',
+          quantity: 1,
+          unitPrice: 38,
+          totalPrice: 38,
+          designType: 'standard',
+          size: 'Serves 8-12 people',
+          flavor: 'Red Velvet'
+        }
+      ],
+      delivery: {
+        dateNeeded: '2026-07-11',
+        deliveryMethod: 'local-delivery',
+        deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR'
+      },
+      pricing: {
+        total: 38,
+        paymentStatus: 'paid',
+        paymentMethod: 'card'
+      },
+      messages: [],
+      notes: [],
+      metadata: {
+        inlineOrderContext: {
+          customerMessage: 'Please write Happy Birthday on the cake'
+        }
+      }
+    }
+
+    mockGetSupabaseOrderByIdentifier.mockResolvedValueOnce(currentOrder)
+    mockUpdateSupabaseOrder.mockImplementation(async (order: typeof currentOrder) => ({
+      ...order,
+      _updatedAt: '2026-05-12T18:10:00.000Z'
+    }))
+
+    const request = new NextRequest('http://localhost/api/orders/order-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        status: 'out-delivery'
+      })
+    })
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'order-1' }) })
+
+    expect(response.status).toBe(200)
+
+    const sendCall = mockSendEmail.mock.calls[0]?.[0]
+    expect(sendCall.input.customerMessage).toBe('Please write Happy Birthday on the cake')
+  })
+
+  it('uses order message when item and metadata customer message are empty', async () => {
+    const currentOrder = {
+      _id: 'order-1',
+      _createdAt: '2026-05-12T18:00:00.000Z',
+      _updatedAt: '2026-05-12T18:00:00.000Z',
+      orderNumber: '26060501334629',
+      status: 'in-progress',
+      orderType: 'custom-cake',
+      customer: {
+        name: 'Igor Ieromenko',
+        email: 'igor@example.com',
+        phone: '07123456789'
+      },
+      items: [
+        {
+          productName: 'Vintage Red Velvet Cake',
+          productId: 'vintage-red-velvet-cake',
+          productType: 'cake',
+          quantity: 1,
+          unitPrice: 38,
+          totalPrice: 38,
+          designType: 'standard',
+          size: 'Serves 8-12 people',
+          flavor: 'Red Velvet'
+        }
+      ],
+      delivery: {
+        dateNeeded: '2026-07-08',
+        deliveryMethod: 'postal',
+        deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR'
+      },
+      pricing: {
+        total: 38,
+        paymentStatus: 'paid',
+        paymentMethod: 'card'
+      },
+      messages: [
+        {
+          message: 'Product: Vintage Red Velvet Cake\nMessage: Please add candles'
+        }
+      ],
+      notes: [],
+      metadata: {}
+    }
+
+    mockGetSupabaseOrderByIdentifier.mockResolvedValueOnce(currentOrder)
+    mockUpdateSupabaseOrder.mockImplementation(async (order: typeof currentOrder) => ({
+      ...order,
+      _updatedAt: '2026-05-12T18:10:00.000Z'
+    }))
+
+    const request = new NextRequest('http://localhost/api/orders/order-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        status: 'out-delivery'
+      })
+    })
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'order-1' }) })
+
+    expect(response.status).toBe(200)
+
+    const sendCall = mockSendEmail.mock.calls[0]?.[0]
+    expect(sendCall.input.customerMessage).toBe('Please add candles')
+  })
+
+  it('filters generated metadata customer message from status emails', async () => {
+    const generatedSummary = [
+      'Product: Vintage Red Velvet Cake',
+      'Product type: cake',
+      'Design type: standard',
+      'Filling: Red Velvet',
+      'Serves 8-12 people',
+      'Price: \u00A338'
+    ].join('\n')
+    const currentOrder = {
+      _id: 'order-1',
+      _createdAt: '2026-05-12T18:00:00.000Z',
+      _updatedAt: '2026-05-12T18:00:00.000Z',
+      orderNumber: '26060623195079',
+      status: 'in-progress',
+      orderType: 'custom-cake',
+      customer: {
+        name: 'Igor Ieromenko',
+        email: 'igor@example.com',
+        phone: '07123456789'
+      },
+      items: [
+        {
+          productName: 'Vintage Red Velvet Cake',
+          productId: 'vintage-red-velvet-cake',
+          productType: 'cake',
+          quantity: 1,
+          unitPrice: 38,
+          totalPrice: 38
+        }
+      ],
+      delivery: {
+        dateNeeded: '2026-07-11',
+        deliveryMethod: 'local-delivery',
+        deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR'
+      },
+      pricing: {
+        total: 38,
+        paymentStatus: 'paid',
+        paymentMethod: 'card'
+      },
+      messages: [],
+      notes: [],
+      metadata: {
+        inlineOrderContext: {
+          customerMessage: generatedSummary
+        }
+      }
+    }
+
+    mockGetSupabaseOrderByIdentifier.mockResolvedValueOnce(currentOrder)
+    mockUpdateSupabaseOrder.mockImplementation(async (order: typeof currentOrder) => ({
+      ...order,
+      _updatedAt: '2026-05-12T18:10:00.000Z'
+    }))
+
+    const request = new NextRequest('http://localhost/api/orders/order-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        status: 'out-delivery'
+      })
+    })
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'order-1' }) })
+
+    expect(response.status).toBe(200)
+
+    const sendCall = mockSendEmail.mock.calls[0]?.[0]
+    expect(sendCall.input.customerMessage).toBeUndefined()
+  })
+
+  it('uses custom cake wording for delivered postal cake orders', async () => {
+    const currentOrder = {
+      _id: 'order-1',
+      _createdAt: '2026-05-12T18:00:00.000Z',
+      _updatedAt: '2026-05-12T18:00:00.000Z',
+      orderNumber: '26060623310313',
+      status: 'out-for-delivery',
+      orderType: 'custom-cake',
+      customer: {
+        name: 'Igor Ieromenko',
+        email: 'igor@example.com',
+        phone: '07123456789',
+        address: '15 Allerton Grange Avenue',
+        city: 'Leeds',
+        postcode: 'LS17 6PR'
+      },
+      items: [
+        {
+          productName: 'Vintage Red Velvet Cake',
+          productId: 'vintage-red-velvet-cake',
+          productType: 'cake',
+          quantity: 1,
+          unitPrice: 38,
+          totalPrice: 38
+        }
+      ],
+      delivery: {
+        dateNeeded: '2026-07-11',
+        deliveryMethod: 'postal',
+        deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
+        trackingNumber: '12345'
+      },
+      pricing: {
+        total: 38,
+        paymentStatus: 'paid',
+        paymentMethod: 'card'
+      },
+      messages: [],
+      notes: [],
+      metadata: {
+        deliveryCourier: 'royal-mail'
+      }
+    }
+
+    mockGetSupabaseOrderByIdentifier.mockResolvedValueOnce(currentOrder)
+    mockUpdateSupabaseOrder.mockImplementation(async (order: typeof currentOrder) => ({
+      ...order,
+      _updatedAt: '2026-05-12T18:10:00.000Z'
+    }))
+
+    const request = new NextRequest('http://localhost/api/orders/order-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        status: 'delivered'
+      })
+    })
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'order-1' }) })
+
+    expect(response.status).toBe(200)
+
+    const sendCall = mockSendEmail.mock.calls[0]?.[0]
+    expect(sendCall.input).toMatchObject({
+      status: 'delivered',
+      productType: 'cake',
+      deliveryMethod: 'postal',
+      headingOverride: 'Order delivered',
+      titleOverride: 'Order Delivered #26060623310313 - Olgish Cakes',
+      statusMessage: 'Your order has been delivered. We hope you enjoy your cake.'
+    })
+    expect(sendCall.input.statusMessage).not.toContain('cakes by post')
+    expect(sendCall.input.statusMessage).not.toContain('cake by post')
+  })
+
+  it('uses cake wording when a stale cakes-by-post order type contains cake items', async () => {
+    const currentOrder = {
+      _id: 'order-1',
+      _createdAt: '2026-05-12T18:00:00.000Z',
+      _updatedAt: '2026-05-12T18:00:00.000Z',
+      orderNumber: '26060501382235',
+      status: 'out-for-delivery',
+      orderType: 'cakes-by-post',
+      customer: {
+        name: 'Igor Ieromenko',
+        email: 'igor@example.com',
+        phone: '07123456789',
+        address: '15 Allerton Grange Avenue',
+        city: 'Leeds',
+        postcode: 'LS17 6PR'
+      },
+      items: [
+        {
+          productName: 'Vintage Red Velvet Cake',
+          productId: 'vintage-red-velvet-cake',
+          productType: 'cake',
+          quantity: 1,
+          unitPrice: 38,
+          totalPrice: 38
+        }
+      ],
+      delivery: {
+        dateNeeded: '2026-07-07',
+        deliveryMethod: 'postal',
+        deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
+        trackingNumber: '12345'
+      },
+      pricing: {
+        total: 38,
+        paymentStatus: 'paid',
+        paymentMethod: 'card'
+      },
+      messages: [],
+      notes: [],
+      metadata: {
+        deliveryCourier: 'evri'
+      }
+    }
+
+    mockGetSupabaseOrderByIdentifier.mockResolvedValueOnce(currentOrder)
+    mockUpdateSupabaseOrder.mockImplementation(async (order: typeof currentOrder) => ({
+      ...order,
+      _updatedAt: '2026-05-12T18:10:00.000Z'
+    }))
+
+    const request = new NextRequest('http://localhost/api/orders/order-1', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        status: 'delivered'
+      })
+    })
+
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'order-1' }) })
+
+    expect(response.status).toBe(200)
+
+    const sendCall = mockSendEmail.mock.calls[0]?.[0]
+    expect(sendCall.input).toMatchObject({
+      orderType: 'cakes-by-post',
+      productType: 'cake',
+      status: 'delivered',
+      headingOverride: 'Order delivered',
+      titleOverride: 'Order Delivered #26060501382235 - Olgish Cakes',
+      statusMessage: 'Your order has been delivered. We hope you enjoy your cake.'
+    })
+    expect(sendCall.input.statusMessage).not.toContain('cakes by post')
   })
 
   it('updates delivery address from a JSON admin edit', async () => {
@@ -714,7 +1230,7 @@ describe('/api/orders/[id] PATCH', () => {
     expect(sendCall.input).toMatchObject({
       status: 'out-for-delivery',
       deliveryCourier: 'evri',
-      statusMessage: 'Great news, your cakes by post order has been dispatched with Evri.'
+      statusMessage: 'Great news, your cake by post order has been dispatched with Evri.'
     })
   })
 

--- a/app/api/orders/[id]/route.ts
+++ b/app/api/orders/[id]/route.ts
@@ -1,7 +1,8 @@
 import { isAdminAuthenticated } from '@/lib/admin-auth'
+import { getCustomerEmailBcc } from '@/lib/email/customer-bcc'
 import { getEmailTransportMode, requiresLiveEmailConfiguration, sendEmail } from '@/lib/email/service'
 import { logger } from '@/lib/logger'
-import { isCakesByPostOrderLike } from '@/lib/order-types'
+import { isCakesByPostOrderType, isCakesByPostProductType } from '@/lib/order-types'
 import {
   deleteSupabaseOrder,
   getSupabaseOrderByIdentifier,
@@ -61,6 +62,92 @@ function getDeliveryCourierLabel(order: Order): string {
   const courier = getDeliveryCourier(order) || 'evri'
 
   return deliveryCourierLabels[courier]
+}
+
+function getPostalOrderDescription(order: Order): 'cake by post order' | 'cake order' {
+  return isCakesByPostSourceOrder(order) ? 'cake by post order' : 'cake order'
+}
+
+function isCakesByPostSourceOrder(order: Order): boolean {
+  const productTypes = order.items
+    .map((item) => item.productType?.trim())
+    .filter((productType): productType is string => Boolean(productType))
+
+  if (productTypes.length > 0) {
+    return productTypes.some(isCakesByPostProductType)
+  }
+
+  return isCakesByPostOrderType(order.orderType)
+}
+
+function isGeneratedProductSummary(value: string | undefined): boolean {
+  const normalizedValue = value?.trim().toLowerCase() || ''
+
+  return normalizedValue.includes('product:') &&
+    normalizedValue.includes('product type:') &&
+    normalizedValue.includes('price:')
+}
+
+function extractExplicitCustomerMessage(value: string | undefined): string | undefined {
+  const lines = value?.split(/\r?\n/) || []
+  const messageLine = lines.find((line) => {
+    const normalizedLine = line.trim().toLowerCase()
+    return normalizedLine.startsWith('message:') ||
+      normalizedLine.startsWith('customer message:') ||
+      normalizedLine.startsWith('requirements:')
+  })
+
+  if (!messageLine) {
+    return undefined
+  }
+
+  return messageLine.replace(/^(message|customer message|requirements):\s*/i, '').trim() || undefined
+}
+
+function resolveCustomerMessage(value: string | undefined): string | undefined {
+  const explicitMessage = extractExplicitCustomerMessage(value)
+  if (explicitMessage) {
+    return resolveCustomerMessage(explicitMessage)
+  }
+
+  const trimmedValue = value?.trim() || ''
+  const normalizedValue = trimmedValue.toLowerCase()
+
+  if (
+    trimmedValue.length === 0 ||
+    normalizedValue === 'message' ||
+    normalizedValue === 'test message' ||
+    isGeneratedProductSummary(trimmedValue)
+  ) {
+    return undefined
+  }
+
+  return trimmedValue
+}
+
+function getStringRecordField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+
+  return typeof value === 'string' ? value : undefined
+}
+
+function getOrderMetadataCustomerMessage(order: Order): string | undefined {
+  if (!isRecord(order.metadata)) {
+    return undefined
+  }
+
+  const inlineOrderContext = isRecord(order.metadata.inlineOrderContext)
+    ? order.metadata.inlineOrderContext
+    : undefined
+
+  return getStringRecordField(inlineOrderContext || {}, 'customerMessage') ||
+    getStringRecordField(order.metadata, 'customerMessage')
+}
+
+function getStatusEmailCustomerMessage(order: Order, firstItem: Order['items'][number] | undefined): string | undefined {
+  return resolveCustomerMessage(firstItem?.specialInstructions) ||
+    resolveCustomerMessage(getOrderMetadataCustomerMessage(order)) ||
+    resolveCustomerMessage(order.messages?.find((message) => resolveCustomerMessage(message.message))?.message)
 }
 
 function getFormString(formData: FormData, key: string): string | undefined {
@@ -569,11 +656,7 @@ async function sendStatusUpdateEmail(order: Order, newStatus: string) {
     return
   }
 
-  const isCakesByPostOrder = isCakesByPostOrderLike({
-    orderType: order.orderType,
-    deliveryMethod: order.delivery.deliveryMethod,
-    itemProductTypes: order.items.map((item) => item.productType)
-  })
+  const isCakesByPostOrder = isCakesByPostSourceOrder(order)
 
   const statusMessages = {
     confirmed: {
@@ -607,10 +690,11 @@ async function sendStatusUpdateEmail(order: Order, newStatus: string) {
 
         if (deliveryMethod === 'postal' || deliveryMethod === 'postal-delivery') {
           const courierLabel = getDeliveryCourierLabel(order)
+          const orderDescription = getPostalOrderDescription(order)
 
           return order.delivery.trackingNumber
-            ? `Great news, your cakes by post order has been dispatched with ${courierLabel}.`
-            : `Great news, your cakes by post order has been dispatched with ${courierLabel} and is on the way.`
+            ? `Great news, your ${orderDescription} has been dispatched with ${courierLabel}.`
+            : `Great news, your ${orderDescription} has been dispatched with ${courierLabel} and is on the way.`
         }
 
         if (deliveryMethod === 'local-delivery') {
@@ -696,7 +780,7 @@ async function sendStatusUpdateEmail(order: Order, newStatus: string) {
         designType: firstItem?.designType,
         filling: firstItem?.flavor,
         servings: firstItem?.size,
-        customerMessage: firstItem?.specialInstructions,
+        customerMessage: getStatusEmailCustomerMessage(order, firstItem),
         deliveryMethod: order.delivery.deliveryMethod,
         deliveryRecipientName: order.delivery.recipientName || order.customer.name,
         deliveryAddress: order.delivery.deliveryAddress,
@@ -713,7 +797,7 @@ async function sendStatusUpdateEmail(order: Order, newStatus: string) {
       message: {
         from: 'Olgish Cakes <hello@olgishcakes.co.uk>',
         to: order.customer.email,
-        bcc: process.env.ADMIN_BCC_EMAIL || undefined
+        bcc: getCustomerEmailBcc(process.env.ADMIN_BCC_EMAIL)
       }
     })
 

--- a/app/api/orders/__tests__/route.test.ts
+++ b/app/api/orders/__tests__/route.test.ts
@@ -104,10 +104,72 @@ describe('/api/orders POST', () => {
       })
     }))
     expect(mockSendEmail).toHaveBeenCalledTimes(2)
+    expect(mockSendEmail.mock.calls[0]?.[0].input.customerMessage).toBe('Please make it less sweet')
     expect(mockUpdateSupabaseOrderMetadata).toHaveBeenCalledWith('order-1', {}, expect.objectContaining({
       emailSent: false,
       emailError: expect.stringContaining('Transport did not accept the customer email')
     }))
+  })
+
+  it('extracts customer message from generated order message for customer emails', async () => {
+    mockSendEmail
+      .mockResolvedValueOnce({
+        mode: 'disabled',
+        accepted: true,
+        id: 'customer-id-1',
+        error: null,
+        rendered: {
+          subject: 'Customer subject',
+          text: 'Customer text',
+          html: '<p>Customer</p>'
+        }
+      })
+      .mockResolvedValueOnce({
+        mode: 'disabled',
+        accepted: true,
+        id: 'admin-id-1',
+        error: null,
+        rendered: {
+          subject: 'Admin subject',
+          text: 'Admin text',
+          html: '<p>Admin</p>'
+        }
+      })
+
+    const request = new NextRequest('http://localhost/api/orders', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        name: 'John Doe',
+        email: 'john@example.com',
+        phone: '07123456789',
+        message: 'Product: Vintage Red Velvet Cake\nProduct type: cake\nPrice: \u00A338\nMessage: Please add candles',
+        orderType: 'standard',
+        productType: 'cake',
+        productName: 'Vintage Red Velvet Cake',
+        designType: 'standard',
+        quantity: 1,
+        unitPrice: 38,
+        totalPrice: 38,
+        deliveryMethod: 'collection',
+        paymentMethod: 'cash-collection'
+      })
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(mockCreateSupabaseOrder).toHaveBeenCalledWith(expect.objectContaining({
+      items: [
+        expect.objectContaining({
+          specialInstructions: 'Please add candles'
+        })
+      ]
+    }))
+    expect(mockSendEmail.mock.calls[0]?.[0].input.customerMessage).toBe('Please add candles')
+    expect(mockSendEmail.mock.calls[1]?.[0].input.customerMessage).toBe('Please add candles')
   })
 
   it('normalizes legacy cakes by post order types before saving', async () => {

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -4,6 +4,7 @@ import { generateOrderNumber } from '@/lib/order-utils'
 import { withRateLimit } from '@/lib/rate-limit'
 import { getRequestIpLocation } from '@/lib/request-location'
 import { formatValidationErrors, orderSchema, validateRequest } from '@/lib/validation'
+import { getCustomerEmailBcc } from '@/lib/email/customer-bcc'
 import { getEmailTransportMode, requiresLiveEmailConfiguration, sendEmail } from '@/lib/email/service'
 import { sendTelegramManagerNotification } from '@/lib/notifications/telegram'
 import { resolveCanonicalOrderType } from '@/lib/order-types'
@@ -98,6 +99,56 @@ function normalizeEmailOrderItems(items: OrderItem[]) {
   }))
 }
 
+function isGeneratedProductSummary(value: string | undefined): boolean {
+  const normalizedValue = value?.trim().toLowerCase() || ''
+
+  return normalizedValue.includes('product:') &&
+    normalizedValue.includes('product type:') &&
+    normalizedValue.includes('price:')
+}
+
+function extractExplicitCustomerMessage(value: string | undefined): string | undefined {
+  const lines = value?.split(/\r?\n/) || []
+  const messageLine = lines.find((line) => {
+    const normalizedLine = line.trim().toLowerCase()
+    return normalizedLine.startsWith('message:') ||
+      normalizedLine.startsWith('customer message:') ||
+      normalizedLine.startsWith('requirements:')
+  })
+
+  if (!messageLine) {
+    return undefined
+  }
+
+  return messageLine.replace(/^(message|customer message|requirements):\s*/i, '').trim() || undefined
+}
+
+function resolveCustomerMessage(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const explicitMessage = extractExplicitCustomerMessage(value)
+    if (explicitMessage) {
+      const resolvedExplicitMessage = resolveCustomerMessage(explicitMessage)
+      if (resolvedExplicitMessage) {
+        return resolvedExplicitMessage
+      }
+    }
+
+    const trimmedValue = value?.trim() || ''
+    const normalizedValue = trimmedValue.toLowerCase()
+
+    if (
+      trimmedValue.length > 0 &&
+      normalizedValue !== 'message' &&
+      normalizedValue !== 'test message' &&
+      !isGeneratedProductSummary(trimmedValue)
+    ) {
+      return trimmedValue
+    }
+  }
+
+  return undefined
+}
+
 function getAttachmentLabel(attachment: Attachment) {
   return attachment.alt || attachment.caption || 'Attachment'
 }
@@ -159,6 +210,10 @@ async function handlePOST(request: NextRequest) {
 
     const validatedOrderData = validationResult.data
     const orderNumber = generateOrderNumber()
+    const resolvedCustomerMessage = resolveCustomerMessage(
+      validatedOrderData.specialInstructions,
+      validatedOrderData.message
+    )
 
     const fallbackItem: OrderItem = {
       productType: validatedOrderData.productType,
@@ -170,7 +225,7 @@ async function handlePOST(request: NextRequest) {
       totalPrice: validatedOrderData.totalPrice || 0,
       size: validatedOrderData.size || '',
       flavor: validatedOrderData.flavor || '',
-      specialInstructions: validatedOrderData.specialInstructions || ''
+      specialInstructions: resolvedCustomerMessage || ''
     }
 
     const items = Array.isArray(orderData.items) && orderData.items.length > 0
@@ -308,7 +363,7 @@ async function handlePOST(request: NextRequest) {
           designType: firstItem?.designType,
           filling: firstItem?.flavor,
           servings: firstItem?.size,
-          customerMessage: firstItem?.specialInstructions || validatedOrderData.specialInstructions,
+          customerMessage: resolveCustomerMessage(firstItem?.specialInstructions, resolvedCustomerMessage),
           deliveryMethod: toDeliveryMethodLabel(validatedOrderData.deliveryMethod || 'collection'),
           deliveryAddress: validatedOrderData.deliveryAddress,
           paymentMethod: toPaymentMethodLabel(validatedOrderData.paymentMethod || 'cash-collection'),
@@ -320,7 +375,7 @@ async function handlePOST(request: NextRequest) {
         message: {
           from: 'Olgish Cakes <hello@olgishcakes.co.uk>',
           to: validatedOrderData.email,
-          bcc: process.env.ADMIN_BCC_EMAIL || undefined
+          bcc: getCustomerEmailBcc(process.env.ADMIN_BCC_EMAIL)
         }
       })
 
@@ -378,7 +433,7 @@ async function handlePOST(request: NextRequest) {
           designType: firstItem?.designType,
           filling: firstItem?.flavor,
           servings: firstItem?.size,
-          customerMessage: firstItem?.specialInstructions || validatedOrderData.specialInstructions,
+          customerMessage: resolveCustomerMessage(firstItem?.specialInstructions, resolvedCustomerMessage),
           deliveryMethod: toDeliveryMethodLabel(validatedOrderData.deliveryMethod || 'collection'),
           deliveryAddress: validatedOrderData.deliveryAddress,
           paymentMethod: toPaymentMethodLabel(validatedOrderData.paymentMethod || 'cash-collection'),

--- a/app/api/workshop-enquiry/route.ts
+++ b/app/api/workshop-enquiry/route.ts
@@ -6,6 +6,7 @@ import {
   requiresLiveEmailConfiguration,
   sendEmail
 } from '@/lib/email/service'
+import { getCustomerEmailBcc } from '@/lib/email/customer-bcc'
 import { sendTelegramManagerNotification } from '@/lib/notifications/telegram'
 import {
   applyEnquiryRateLimitHeaders,
@@ -312,15 +313,15 @@ export async function POST(request: NextRequest) {
           designType: validated.decorationTheme,
           customerMessage: validated.brief,
           nextSteps: [
-            'I will review the date and location details first.',
-            'If the workshop format is a fit, I will come back with the next practical steps.'
+            'We will review the date and location details first.',
+            'If the workshop format is a fit, we will come back with the next practical steps.'
           ]
         },
         modeOverride: emailMode,
         message: {
           from: getEmailFromAddress(),
           to: validated.email,
-          bcc: process.env.ADMIN_BCC_EMAIL || undefined,
+          bcc: getCustomerEmailBcc(process.env.ADMIN_BCC_EMAIL),
           replyTo: getRecipientEmail()
         }
       })

--- a/app/cakes/components/CatalogProductDetailLayout.tsx
+++ b/app/cakes/components/CatalogProductDetailLayout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image, { getImageProps } from 'next/image'
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState, type FocusEvent as ReactFocusEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type ReactNode, type TouchEvent as ReactTouchEvent } from 'react'
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState, type FocusEvent as ReactFocusEvent, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
 import { normalizePathname, readPreviousPathnameFromHistoryState } from '@/app/utils/history-state'
 import { getSanityCdnImageLoader, isSanityCdnImageUrl } from '@/lib/utils/image-url'
 
@@ -76,9 +76,8 @@ const fallbackImage: CatalogProductDetailImage = {
   src: '/images/placeholder-cake.jpg',
   alt: 'Product image placeholder'
 }
-const swipeNavigationMinDistancePx = 48
-const swipeNavigationMaxVerticalDriftPx = 24
-const swipeNavigationHorizontalDominanceRatio = 1.25
+const swipeNavigationMinDistancePx = 40
+const swipeNavigationHorizontalDominanceRatio = 1.4
 
 const pricePrefixClass = '[font-family:var(--font-more-sugar),cursive,fantasy] [font-weight:var(--t-font-weight-bold)] [font-style:normal] [font-size:12px] tablet:[font-size:var(--t-font-size-subtitle-small)] [leading-trim:none] [line-height:100%] [letter-spacing:-0.02em] align-top text-primary-500'
 const tabletPriceSignClass = 'tablet:[font-family:var(--font-more-sugar),cursive,fantasy] tablet:[font-weight:var(--t-font-weight-bold)] tablet:[font-style:normal] tablet:[font-size:var(--t-font-size-subtitle-small)] tablet:[leading-trim:none] tablet:[line-height:100%] tablet:[letter-spacing:-0.02em] tablet:align-top tablet:text-primary-500'
@@ -250,10 +249,11 @@ export function CatalogProductDetailLayout({
   const preloadedGalleryImageSrcsRef = useRef(new Set<string>())
   const activeGalleryPreloadImagesRef = useRef(new Map<string, HTMLImageElement>())
   const readyGalleryImageSrcsRef = useRef(new Set<string>())
-  const touchStartXRef = useRef<number | null>(null)
-  const touchStartYRef = useRef<number | null>(null)
-  const touchCurrentXRef = useRef<number | null>(null)
-  const touchCurrentYRef = useRef<number | null>(null)
+  const pointerStartXRef = useRef<number | null>(null)
+  const pointerStartYRef = useRef<number | null>(null)
+  const pointerCurrentXRef = useRef<number | null>(null)
+  const pointerCurrentYRef = useRef<number | null>(null)
+  const pointerIdRef = useRef<number | null>(null)
   const isSwipeTrackingRef = useRef(false)
   const resolvedImages = useMemo(() => {
     return images.length > 0 ? images : [fallbackImage]
@@ -395,10 +395,11 @@ export function CatalogProductDetailLayout({
   }, [canStartImageTransition, prefersReducedMotion, resolvedImages])
 
   const resetSwipeTrackingState = useCallback(() => {
-    touchStartXRef.current = null
-    touchStartYRef.current = null
-    touchCurrentXRef.current = null
-    touchCurrentYRef.current = null
+    pointerStartXRef.current = null
+    pointerStartYRef.current = null
+    pointerCurrentXRef.current = null
+    pointerCurrentYRef.current = null
+    pointerIdRef.current = null
     isSwipeTrackingRef.current = false
   }, [])
 
@@ -482,73 +483,71 @@ export function CatalogProductDetailLayout({
     }
   }, [handleNextImage, handlePreviousImage, isMultiImageGallery])
 
-  const handleGalleryTouchStart = useCallback((event: ReactTouchEvent<HTMLElement>) => {
-    if (!isMultiImageGallery || event.touches.length !== 1) {
+  const handleGalleryPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    if (!isMultiImageGallery || event.isPrimary === false) {
       resetSwipeTrackingState()
       return
     }
 
     focusGalleryRegion()
 
-    const touchPoint = event.touches[0]
-    touchStartXRef.current = touchPoint.clientX
-    touchStartYRef.current = touchPoint.clientY
-    touchCurrentXRef.current = touchPoint.clientX
-    touchCurrentYRef.current = touchPoint.clientY
+    pointerStartXRef.current = event.clientX
+    pointerStartYRef.current = event.clientY
+    pointerCurrentXRef.current = event.clientX
+    pointerCurrentYRef.current = event.clientY
+    pointerIdRef.current = event.pointerId
     isSwipeTrackingRef.current = true
+
+    if (typeof event.currentTarget.setPointerCapture === 'function') {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId)
+      } catch {
+        // Some test and automation environments do not create an active native pointer.
+      }
+    }
   }, [focusGalleryRegion, isMultiImageGallery, resetSwipeTrackingState])
 
-  const handleGalleryTouchMove = useCallback((event: ReactTouchEvent<HTMLElement>) => {
-    if (!isSwipeTrackingRef.current) {
+  const handleGalleryPointerMove = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    if (!isSwipeTrackingRef.current || pointerIdRef.current !== event.pointerId) {
       return
     }
 
-    if (event.touches.length !== 1) {
+    pointerCurrentXRef.current = event.clientX
+    pointerCurrentYRef.current = event.clientY
+  }, [])
+
+  const handleGalleryPointerUp = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    if (!isMultiImageGallery || !isSwipeTrackingRef.current || pointerIdRef.current !== event.pointerId) {
       resetSwipeTrackingState()
       return
     }
 
-    const touchPoint = event.touches[0]
-    touchCurrentXRef.current = touchPoint.clientX
-    touchCurrentYRef.current = touchPoint.clientY
-  }, [resetSwipeTrackingState])
+    const pointerStartX = pointerStartXRef.current
+    const pointerStartY = pointerStartYRef.current
 
-  const handleGalleryTouchEnd = useCallback((event: ReactTouchEvent<HTMLElement>) => {
-    if (!isMultiImageGallery || !isSwipeTrackingRef.current) {
+    if (pointerStartX === null || pointerStartY === null) {
       resetSwipeTrackingState()
       return
     }
 
-    const touchStartX = touchStartXRef.current
-    const touchStartY = touchStartYRef.current
+    const pointerEndX = event.clientX ?? pointerCurrentXRef.current
+    const pointerEndY = event.clientY ?? pointerCurrentYRef.current
 
-    if (touchStartX === null || touchStartY === null) {
+    if (pointerEndX === null || pointerEndY === null) {
       resetSwipeTrackingState()
       return
     }
 
-    const changedTouchPoint = event.changedTouches.length > 0
-      ? event.changedTouches[0]
-      : null
-    const touchEndX = changedTouchPoint?.clientX ?? touchCurrentXRef.current
-    const touchEndY = changedTouchPoint?.clientY ?? touchCurrentYRef.current
-
-    if (touchEndX === null || touchEndY === null) {
-      resetSwipeTrackingState()
-      return
-    }
-
-    const deltaX = touchEndX - touchStartX
-    const deltaY = touchEndY - touchStartY
+    const deltaX = pointerEndX - pointerStartX
+    const deltaY = pointerEndY - pointerStartY
     const absDeltaX = Math.abs(deltaX)
     const absDeltaY = Math.abs(deltaY)
     const hasSufficientSwipeDistance = absDeltaX >= swipeNavigationMinDistancePx
-    const hasAcceptableVerticalDrift = absDeltaY <= swipeNavigationMaxVerticalDriftPx
     const isHorizontallyDominantGesture = absDeltaX >= absDeltaY * swipeNavigationHorizontalDominanceRatio
 
     resetSwipeTrackingState()
 
-    if (!hasSufficientSwipeDistance || !hasAcceptableVerticalDrift || !isHorizontallyDominantGesture) {
+    if (!hasSufficientSwipeDistance || !isHorizontallyDominantGesture) {
       return
     }
 
@@ -567,7 +566,7 @@ export function CatalogProductDetailLayout({
     resetSwipeTrackingState
   ])
 
-  const handleGalleryTouchCancel = useCallback(() => {
+  const handleGalleryPointerCancel = useCallback(() => {
     resetSwipeTrackingState()
   }, [resetSwipeTrackingState])
 
@@ -861,12 +860,12 @@ export function CatalogProductDetailLayout({
             Image {normalizedDisplayedImageIndex + 1} of {resolvedImages.length}
           </span>
           <div
-            onTouchStart={handleGalleryTouchStart}
-            onTouchMove={handleGalleryTouchMove}
-            onTouchEnd={handleGalleryTouchEnd}
-            onTouchCancel={handleGalleryTouchCancel}
+            onPointerDown={handleGalleryPointerDown}
+            onPointerMove={handleGalleryPointerMove}
+            onPointerUp={handleGalleryPointerUp}
+            onPointerCancel={handleGalleryPointerCancel}
             data-testid='product-gallery-viewport'
-            className={`catalog-gallery-viewport relative -mx-4 aspect-square w-[calc(100%+2rem)] touch-none overflow-hidden rounded-none bg-base-200 ${isGalleryFocused ? 'outline outline-2 outline-offset-2 outline-primary-500' : ''} tablet:mx-0 tablet:w-full tablet:touch-pan-y tablet:rounded-[8px]`}
+            className={`catalog-gallery-viewport relative -mx-4 aspect-square w-[calc(100%+2rem)] touch-pan-y overflow-hidden rounded-none bg-base-200 ${isGalleryFocused ? 'outline outline-2 outline-offset-2 outline-primary-500' : ''} tablet:mx-0 tablet:w-full tablet:rounded-[8px]`}
           >
             <div
               data-testid='product-gallery-stage'

--- a/app/cakes/components/__tests__/CatalogProductDetailLayout.test.tsx
+++ b/app/cakes/components/__tests__/CatalogProductDetailLayout.test.tsx
@@ -435,30 +435,54 @@ function fireGallerySwipeGesture({
   endX: number
   endY: number
 }) {
-  const startTouchPoint = createTouchPoint({
+  fireGalleryPointerEvent(element, 'pointerdown', {
     clientX: startX,
-    clientY: startY
+    clientY: startY,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'touch'
   })
-  const endTouchPoint = createTouchPoint({
+  fireGalleryPointerEvent(element, 'pointermove', {
     clientX: endX,
-    clientY: endY
+    clientY: endY,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'touch'
+  })
+  fireGalleryPointerEvent(element, 'pointerup', {
+    clientX: endX,
+    clientY: endY,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'touch'
+  })
+}
+
+function fireGalleryPointerEvent(
+  element: HTMLElement,
+  type: string,
+  eventInit: {
+    clientX: number
+    clientY: number
+    isPrimary: boolean
+    pointerId: number
+    pointerType: string
+  }
+) {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true
   })
 
-  fireEvent.touchStart(element, {
-    touches: [startTouchPoint],
-    changedTouches: [startTouchPoint],
-    targetTouches: [startTouchPoint]
+  Object.defineProperties(event, {
+    clientX: { value: eventInit.clientX },
+    clientY: { value: eventInit.clientY },
+    isPrimary: { value: eventInit.isPrimary },
+    pointerId: { value: eventInit.pointerId },
+    pointerType: { value: eventInit.pointerType }
   })
-  fireEvent.touchMove(element, {
-    touches: [endTouchPoint],
-    changedTouches: [endTouchPoint],
-    targetTouches: [endTouchPoint]
-  })
-  fireEvent.touchEnd(element, {
-    touches: [],
-    changedTouches: [endTouchPoint],
-    targetTouches: []
-  })
+
+  fireEvent(element, event)
 }
 
 function fireNativeClickSequence(elements: HTMLElement[]) {
@@ -587,12 +611,13 @@ describe('CatalogProductDetailLayout', () => {
     expect(imageWrapper).not.toHaveClass('rounded-box')
   })
 
-  it('uses touch none on mobile and pan-y touch behavior from tablet up on gallery image container', () => {
+  it('allows vertical panning on mobile gallery image container', () => {
     renderLayout()
 
     const imageWrapper = getGalleryViewport()
 
-    expect(imageWrapper).toHaveClass('touch-none', 'tablet:touch-pan-y')
+    expect(imageWrapper).toHaveClass('touch-pan-y')
+    expect(imageWrapper).not.toHaveClass('touch-none')
   })
 
   it('renders a stable gallery layer when no image transition is active', () => {
@@ -1237,7 +1262,7 @@ describe('CatalogProductDetailLayout', () => {
     expect(galleryViewport).not.toHaveClass('outline', 'outline-2', 'outline-offset-2', 'outline-primary-500')
   })
 
-  it('focuses gallery on image touch start so arrows become visible on mobile', () => {
+  it('focuses gallery on image pointer down so arrows become visible on mobile', () => {
     renderLayout()
 
     const galleryRegion = screen.getByRole('region', { name: 'Product gallery' })
@@ -1250,10 +1275,12 @@ describe('CatalogProductDetailLayout', () => {
       clientY: 120
     })
 
-    fireEvent.touchStart(imageWrapper, {
-      touches: [touchPoint],
-      changedTouches: [touchPoint],
-      targetTouches: [touchPoint]
+    fireGalleryPointerEvent(imageWrapper, 'pointerdown', {
+      clientX: touchPoint.clientX,
+      clientY: touchPoint.clientY,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'touch'
     })
 
     expect(galleryRegion).toHaveFocus()
@@ -1856,7 +1883,7 @@ describe('CatalogProductDetailLayout', () => {
       startX: 220,
       startY: 120,
       endX: 140,
-      endY: 160
+      endY: 190
     })
 
     expectActiveImage(1, 2)
@@ -1890,43 +1917,38 @@ describe('CatalogProductDetailLayout', () => {
     expectActiveImage(1, 2)
   })
 
-  it('does not navigate images after touch cancel', () => {
+  it('does not navigate images after pointer cancel', () => {
     renderLayout()
 
     const imageWrapper = getGalleryViewport()
 
-    const startTouchPoint = createTouchPoint({
+    fireGalleryPointerEvent(imageWrapper, 'pointerdown', {
       clientX: 220,
-      clientY: 120
+      clientY: 120,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'touch'
     })
-    const moveTouchPoint = createTouchPoint({
+    fireGalleryPointerEvent(imageWrapper, 'pointermove', {
       clientX: 180,
-      clientY: 124
+      clientY: 124,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'touch'
     })
-    const endTouchPoint = createTouchPoint({
+    fireGalleryPointerEvent(imageWrapper, 'pointercancel', {
+      clientX: 180,
+      clientY: 124,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'touch'
+    })
+    fireGalleryPointerEvent(imageWrapper, 'pointerup', {
       clientX: 80,
-      clientY: 126
-    })
-
-    fireEvent.touchStart(imageWrapper, {
-      touches: [startTouchPoint],
-      changedTouches: [startTouchPoint],
-      targetTouches: [startTouchPoint]
-    })
-    fireEvent.touchMove(imageWrapper, {
-      touches: [moveTouchPoint],
-      changedTouches: [moveTouchPoint],
-      targetTouches: [moveTouchPoint]
-    })
-    fireEvent.touchCancel(imageWrapper, {
-      touches: [],
-      changedTouches: [moveTouchPoint],
-      targetTouches: []
-    })
-    fireEvent.touchEnd(imageWrapper, {
-      touches: [],
-      changedTouches: [endTouchPoint],
-      targetTouches: []
+      clientY: 126,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: 'touch'
     })
 
     expectActiveImage(1, 2)

--- a/app/components/homepage/EnquiryForm.tsx
+++ b/app/components/homepage/EnquiryForm.tsx
@@ -379,7 +379,7 @@ export function EnquiryForm({
               <div>
                 <p className='font-semibold'>Enquiry sent</p>
                 <p className='mt-1 leading-6'>
-                  Thank you, your cake enquiry has arrived safely. I&apos;ll get back to you as soon as I can.
+                  Thank you, your cake enquiry has arrived safely. We&apos;ll get back to you as soon as we can.
                 </p>
               </div>
             </div>

--- a/app/components/homepage/ProductOrderInlineForm.tsx
+++ b/app/components/homepage/ProductOrderInlineForm.tsx
@@ -250,8 +250,8 @@ export function ProductOrderInlineForm({
     : 'bg-primary-500 hover:bg-primary-700'
   const buttonLabel = hasSubmittedSuccessfully ? 'Request sent' : 'Submit order'
   const successMessage = isPostalOrder
-    ? "Thank you, your cakes by post request has arrived safely. I'll check the delivery details and send the next steps within 24 hours."
-    : "Thank you, your order request has arrived safely. I'll review the details and get back to you within 24 hours."
+    ? "Thank you, your cakes by post request has arrived safely. We'll check the delivery details and send the next steps within 24 hours."
+    : "Thank you, your order request has arrived safely. We'll review the details and get back to you within 24 hours."
   const userRequestDetails = useMemo(() => {
     const value = requestMode === 'custom-design'
       ? formData.requirements?.trim()

--- a/app/components/homepage/__tests__/ProductOrderInlineForm.test.tsx
+++ b/app/components/homepage/__tests__/ProductOrderInlineForm.test.tsx
@@ -592,7 +592,7 @@ describe('ProductOrderInlineForm', () => {
 
     expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite')
     expect(screen.getByText('Order request received')).toBeInTheDocument()
-    expect(screen.getByText("Thank you, your order request has arrived safely. I'll review the details and get back to you within 24 hours.")).toBeInTheDocument()
+    expect(screen.getByText("Thank you, your order request has arrived safely. We'll review the details and get back to you within 24 hours.")).toBeInTheDocument()
     expect(screen.queryByText("We'll review your details within 24 hours.")).not.toBeInTheDocument()
     expect(screen.queryByText("We'll contact you with a quote and final design details.")).not.toBeInTheDocument()
     expect(screen.queryByText("We'll confirm delivery or collection once you approve.")).not.toBeInTheDocument()
@@ -625,8 +625,8 @@ describe('ProductOrderInlineForm', () => {
 
     expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite')
     expect(screen.getByText('Order request received')).toBeInTheDocument()
-    expect(screen.getByText("Thank you, your cakes by post request has arrived safely. I'll check the delivery details and send the next steps within 24 hours.")).toBeInTheDocument()
-    expect(screen.queryByText("Thank you, your order request has arrived safely. I'll review the details and get back to you within 24 hours.")).not.toBeInTheDocument()
+    expect(screen.getByText("Thank you, your cakes by post request has arrived safely. We'll check the delivery details and send the next steps within 24 hours.")).toBeInTheDocument()
+    expect(screen.queryByText("Thank you, your order request has arrived safely. We'll review the details and get back to you within 24 hours.")).not.toBeInTheDocument()
     expect(screen.queryByText("We'll review your order and delivery details within 24 hours.")).not.toBeInTheDocument()
     expect(screen.queryByText("If everything is confirmed, we'll send you a secure payment link.")).not.toBeInTheDocument()
     expect(screen.queryByText("Once payment is received, we'll prepare, pack, and send your cake by post.")).not.toBeInTheDocument()

--- a/app/contact/ContactPageForm.tsx
+++ b/app/contact/ContactPageForm.tsx
@@ -152,9 +152,6 @@ export function ContactPageForm() {
     }
   }
 
-  const submitLabel = hasSubmittedSuccessfully ? 'Message sent' : 'Send your message'
-  const submitClassName = hasSubmittedSuccessfully ? 'btn-success' : 'btn-primary'
-
   return (
     <form
       id='contact-form'
@@ -257,20 +254,45 @@ export function ContactPageForm() {
       ) : null}
 
       {hasSubmittedSuccessfully ? (
-        <div className='alert alert-success text-sm' role='status'>
-          <span>Thanks. I&apos;ve got your message and I&apos;ll be back in touch soon.</span>
+        <div
+          className='alert alert-success w-full items-start text-sm'
+          role='status'
+          aria-live='polite'
+        >
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            className='h-5 w-5 shrink-0 stroke-current'
+            fill='none'
+            viewBox='0 0 24 24'
+            aria-hidden='true'
+          >
+            <path
+              strokeLinecap='round'
+              strokeLinejoin='round'
+              strokeWidth='2'
+              d='M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
+            />
+          </svg>
+          <div>
+            <p className='font-semibold'>Message sent</p>
+            <p className='mt-1 leading-6'>
+              Thank you, we&apos;ve got your message and we&apos;ll be back in touch soon.
+            </p>
+          </div>
         </div>
       ) : null}
 
       <div>
-        <button
-          type='submit'
-          className={`btn btn-block h-12 border-none px-6 text-sm font-semibold normal-case tablet:h-14 tablet:text-base ${submitClassName}`}
-          disabled={isSubmitting || isCsrfLoading}
-          aria-busy={isSubmitting || isCsrfLoading}
-        >
-          {isSubmitting ? 'Sending...' : submitLabel}
-        </button>
+        {hasSubmittedSuccessfully ? null : (
+          <button
+            type='submit'
+            className='btn btn-primary btn-block h-12 border-none px-6 text-sm font-semibold normal-case tablet:h-14 tablet:text-base'
+            disabled={isSubmitting || isCsrfLoading}
+            aria-busy={isSubmitting || isCsrfLoading}
+          >
+            {isSubmitting ? 'Sending...' : 'Send your message'}
+          </button>
+        )}
       </div>
     </form>
   )

--- a/app/contact/__tests__/ContactPageForm.test.tsx
+++ b/app/contact/__tests__/ContactPageForm.test.tsx
@@ -280,9 +280,10 @@ describe('ContactPageForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /send your message/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /message sent/i })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /send your message/i })).not.toBeInTheDocument()
+      expect(screen.getByRole('status')).toHaveTextContent(/message sent/i)
       expect(
-        screen.getByText(/thanks\. i've got your message and i'll be back in touch soon\./i)
+        screen.getByText(/thank you, we've got your message and we'll be back in touch soon\./i)
       ).toBeInTheDocument()
     })
 

--- a/app/get-custom-quote/GetCustomQuoteCtaBand.tsx
+++ b/app/get-custom-quote/GetCustomQuoteCtaBand.tsx
@@ -11,7 +11,7 @@ export function GetCustomQuoteCtaBand() {
               Ready when the brief is clear
             </p>
             <h2 className='mt-3 font-moreSugar text-[24px] uppercase leading-[1.18] tracking-[0.08em] text-primary-700 tablet:text-[32px]'>
-              Send the essentials and I will take it from there
+              Send the essentials and we will take it from there
             </h2>
             <p className='mt-4 font-oldenburg text-[15px] leading-7 tracking-[0.03em] text-base-content/80 tablet:text-base tablet:leading-8'>
               If you already know the date, servings and general style, the quote form is enough to start a sensible conversation about your cake.

--- a/app/get-custom-quote/GetCustomQuoteFaq.tsx
+++ b/app/get-custom-quote/GetCustomQuoteFaq.tsx
@@ -22,7 +22,7 @@ export const getCustomQuoteFaqItems: QuoteFaqItem[] = [
   },
   {
     question: 'Can you help if I am not sure about size yet?',
-    answer: 'Yes. An approximate guest count is enough for the first quote. Once I know whether the cake is for a smaller dinner, family party or bigger celebration, I can suggest a more realistic starting size.'
+    answer: 'Yes. An approximate guest count is enough for the first quote. Once we know whether the cake is for a smaller dinner, family party or bigger celebration, we can suggest a more realistic starting size.'
   }
 ]
 

--- a/app/get-custom-quote/GetCustomQuoteForm.tsx
+++ b/app/get-custom-quote/GetCustomQuoteForm.tsx
@@ -154,6 +154,11 @@ export function GetCustomQuoteForm({
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+
+    if (hasSubmittedSuccessfully) {
+      return
+    }
+
     setHasAttemptedSubmit(true)
     setErrors({})
     submitMutation.reset()
@@ -215,6 +220,8 @@ export function GetCustomQuoteForm({
   }
 
   const normalizedOccasionOptions = optionalFieldOptions(normalizeOccasionOptions(occasionOptions))
+  const isSubmitDisabled = isSubmitting || isCsrfLoading
+  const submitButtonLabel = isSubmitting ? 'Sending...' : 'Send quote request'
 
   return (
     <form
@@ -305,7 +312,7 @@ export function GetCustomQuoteForm({
         label='Cake brief'
         labelAlt='(Required)'
         labelLayout='stacked'
-        placeholder='Tell me the main idea, style, colours, flavour direction, dietary notes, delivery or collection preference, and anything else that matters.'
+        placeholder='Tell us the main idea, style, colours, flavour direction, dietary notes, delivery or collection preference, and anything else that matters.'
         hintText='Describe the cake briefly, including any extra detail that would help the first reply'
         inputClassName='min-h-40'
         error={errors.brief}
@@ -340,7 +347,7 @@ export function GetCustomQuoteForm({
 
       {hasSubmittedSuccessfully ? (
         <div
-          className='alert alert-success items-start text-sm'
+          className='alert alert-success w-full items-start text-sm'
           role='status'
           aria-live='polite'
         >
@@ -361,24 +368,28 @@ export function GetCustomQuoteForm({
           <div>
             <p className='font-semibold'>Enquiry sent</p>
             <p className='mt-1 leading-6'>
-              Thank you, your cake enquiry has arrived safely. I&apos;ll get back to you as soon as I can.
+              Thank you, your cake enquiry has arrived safely. We&apos;ll get back to you as soon as we can.
             </p>
           </div>
         </div>
       ) : null}
 
       <div className='bottom-3'>
-        <button
-          type='submit'
-          className='btn btn-primary btn-block h-12 border-none px-6 text-sm font-semibold normal-case tablet:h-14 tablet:text-base'
-          disabled={isSubmitting || isCsrfLoading}
-          aria-busy={isSubmitting || isCsrfLoading}
-        >
-          {isSubmitting ? 'Sending...' : 'Send quote request'}
-        </button>
-        <p className='mt-3 text-center text-sm leading-6 text-base-content/70'>
-          I&apos;ll review your enquiry and reply within 24 hours. Please add either an email address or a phone number so I can get back to you.
-        </p>
+        {hasSubmittedSuccessfully ? null : (
+          <button
+            type='submit'
+            className='btn btn-primary btn-block h-12 border-none px-6 text-sm font-semibold normal-case tablet:h-14 tablet:text-base'
+            disabled={isSubmitDisabled}
+            aria-busy={isSubmitting || isCsrfLoading}
+          >
+            {submitButtonLabel}
+          </button>
+        )}
+        {hasSubmittedSuccessfully ? null : (
+          <p className='mt-3 text-center text-sm leading-6 text-base-content/70'>
+            We&apos;ll review your enquiry and reply within 24 hours. Please add either an email address or a phone number so we can get back to you.
+          </p>
+        )}
       </div>
     </form>
   )

--- a/app/get-custom-quote/GetCustomQuoteFormSection.tsx
+++ b/app/get-custom-quote/GetCustomQuoteFormSection.tsx
@@ -18,10 +18,10 @@ export function GetCustomQuoteFormSection({
               Quote form
             </p>
             <h2 className='mt-3 font-moreSugar text-[28px] uppercase leading-[1.2] tracking-[0.1em] text-primary-700 tablet:text-[40px]'>
-              Tell me what you are planning
+              Tell us what you are planning
             </h2>
             <p className='mt-4 font-oldenburg text-[15px] leading-7 tracking-[0.03em] text-base-content/80 tablet:text-base tablet:leading-8'>
-              Start with the details that help me price the cake properly: date, servings, your main design idea, and whether you need collection, local delivery or UK delivery by agreement.
+              Start with the details that help us price the cake properly: date, servings, your main design idea, and whether you need collection, local delivery or UK delivery by agreement.
             </p>
             <p className='mt-4 text-sm leading-6 text-base-content/70'>
               You do not need a finished cake concept before enquiring. A short brief is enough.

--- a/app/get-custom-quote/GetCustomQuoteHero.tsx
+++ b/app/get-custom-quote/GetCustomQuoteHero.tsx
@@ -18,7 +18,7 @@ export function GetCustomQuoteHero() {
               Get a custom cake quote in Leeds
             </h1>
             <p className='mx-auto max-w-[560px] font-oldenburg text-base leading-7 tracking-[0.05em] text-primary-800 tablet:text-[22px] tablet:leading-9 small-laptop:mx-0'>
-              Tell me the date, guest count and the kind of cake you have in mind, and I&apos;ll come back with a quote for your birthday, anniversary, wedding or celebration cake.
+              Tell us the date, guest count and the kind of cake you have in mind, and we&apos;ll come back with a quote for your birthday, anniversary, wedding or celebration cake.
             </p>
           </div>
           <div className='flex w-full flex-col gap-3 tablet:flex-row tablet:justify-center small-laptop:justify-start'>

--- a/app/get-custom-quote/GetCustomQuoteProcess.tsx
+++ b/app/get-custom-quote/GetCustomQuoteProcess.tsx
@@ -2,17 +2,17 @@ const quoteSteps = [
   {
     step: '01',
     title: 'Start with the practical details',
-    body: 'Share the date, rough servings and the occasion. That helps me judge what is realistic, and whether collection, local delivery or UK delivery by agreement would work best.'
+    body: 'Share the date, rough servings and the occasion. That helps us judge what is realistic, and whether collection, local delivery or UK delivery by agreement would work best.'
   },
   {
     step: '02',
     title: 'Add the style direction',
-    body: 'A short description is enough. Colours, finish, flavour ideas and one or two inspiration images usually tell me more than a long wishlist.'
+    body: 'A short description is enough. Colours, finish, flavour ideas and one or two inspiration images usually tell us more than a long wishlist.'
   },
   {
     step: '03',
     title: 'Get a quote you can work with',
-    body: 'My reply will be based on your date and brief, so you get a quote that fits the cake you actually need.'
+    body: 'Our reply will be based on your date and brief, so you get a quote that fits the cake you actually need.'
   }
 ]
 

--- a/app/get-custom-quote/__tests__/GetCustomQuoteForm.test.tsx
+++ b/app/get-custom-quote/__tests__/GetCustomQuoteForm.test.tsx
@@ -129,7 +129,7 @@ describe('GetCustomQuoteForm', () => {
     expect(screen.getByLabelText(/^Occasion/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/^Cake brief/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/^Reference image/i)).toBeInTheDocument()
-    expect(screen.getByText(/please add either an email address or a phone number so i can get back to you/i)).toBeInTheDocument()
+    expect(screen.getByText(/please add either an email address or a phone number so we can get back to you/i)).toBeInTheDocument()
     expect(screen.queryByText(/optional section 1/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/add design, budget and dietary detail/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/add fulfilment and location guidance/i)).not.toBeInTheDocument()
@@ -380,7 +380,8 @@ describe('GetCustomQuoteForm', () => {
     })
 
     expect(screen.getByText(/your cake enquiry has arrived safely/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /send quote request/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /send quote request/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/please add either an email address or a phone number/i)).not.toBeInTheDocument()
 
     expect(screen.queryByText(/selected:\s*cake\.png/i)).not.toBeInTheDocument()
     expect(fileInput.value).toBe('')

--- a/app/get-custom-quote/__tests__/GetCustomQuoteFormSection.test.tsx
+++ b/app/get-custom-quote/__tests__/GetCustomQuoteFormSection.test.tsx
@@ -37,8 +37,8 @@ describe('GetCustomQuoteFormSection', () => {
       />
     )
 
-    expect(screen.getByRole('heading', { level: 2, name: /tell me what you are planning/i })).toBeInTheDocument()
-    expect(screen.getByText(/start with the details that help me price the cake properly/i)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: /tell us what you are planning/i })).toBeInTheDocument()
+    expect(screen.getByText(/start with the details that help us price the cake properly/i)).toBeInTheDocument()
     expect(screen.getByTestId('query-providers')).toBeInTheDocument()
     expect(screen.getByTestId('get-custom-quote-form')).toHaveAttribute('data-occasion-count', '2')
   })

--- a/app/get-custom-quote/__tests__/page.test.tsx
+++ b/app/get-custom-quote/__tests__/page.test.tsx
@@ -18,7 +18,7 @@ const mockedGetCustomQuoteFormSection = jest.fn(({ occasionOptions }: {
   occasionOptions: Array<{ label: string, value?: string, disabled?: boolean }>
 }) => (
   <section id='quote-form'>
-    <h2>Tell me what you are planning</h2>
+    <h2>Tell us what you are planning</h2>
     <div>Mock quote form section</div>
     <div data-testid='occasion-options-count'>{occasionOptions.length}</div>
   </section>
@@ -72,9 +72,9 @@ describe('GetCustomQuotePage', () => {
     expect(screen.getAllByRole('link', { name: /start your quote/i })[0]).toHaveAttribute('href', '/get-custom-quote#quote-form')
     expect(screen.getByRole('heading', { level: 2, name: 'A clear process from the start' })).toBeInTheDocument()
     expect(screen.getAllByRole('heading', { level: 2, name: 'Browse a few good places to start' })).toHaveLength(1)
-    expect(screen.getByText('Tell me what you are planning')).toBeInTheDocument()
+    expect(screen.getByText('Tell us what you are planning')).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 2, name: 'A few practical answers' })).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { level: 2, name: 'Send the essentials and I will take it from there' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { level: 2, name: 'Send the essentials and we will take it from there' })).not.toBeInTheDocument()
     expect(screen.getByText(/collection from leeds, local delivery where suitable, and uk delivery by agreement/i)).toBeInTheDocument()
     expect(screen.queryByText('Review score')).not.toBeInTheDocument()
     expect(screen.queryByText(/reviews from customers ordering handmade cakes/i)).not.toBeInTheDocument()

--- a/docs/EMAIL_SETUP_GUIDE.md
+++ b/docs/EMAIL_SETUP_GUIDE.md
@@ -18,6 +18,17 @@ RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 2. Verify your domain `olgishcakes.co.uk`
 3. Generate an API key in the API Keys section
 
+## Domain Authentication
+
+Production email must be sent from a fully verified Resend domain. Before release, check the Resend dashboard for `olgishcakes.co.uk` and confirm:
+
+- SPF is verified for the configured sending domain.
+- DKIM is verified and outgoing test emails include a `DKIM-Signature` header.
+- The `from` address uses the verified domain, for example `Olgish Cakes <hello@olgishcakes.co.uk>`.
+- DMARC is configured for `olgishcakes.co.uk` so mailbox providers can evaluate SPF/DKIM alignment.
+
+Resend domain verification requires DNS records for SPF and DKIM. Missing DKIM is not fixed by changing the email template; update the DNS records shown in Resend, wait for propagation, then resend a test email and inspect the headers.
+
 ### Optional Variables (with defaults)
 
 ```bash

--- a/env.development.template
+++ b/env.development.template
@@ -42,6 +42,7 @@ CONTACT_EMAIL_TO=hello@olgishcakes.co.uk
 CONTACT_EMAIL_BCC=backup@olgishcakes.co.uk
 ORDER_EMAIL_BCC=orders@olgishcakes.co.uk
 ADMIN_BCC_EMAIL=your_admin_email_for_bcc@example.com
+CUSTOMER_EMAIL_BCC_ENABLED=true
 
 # Supabase
 SUPABASE_URL=your_supabase_url

--- a/env.production.template
+++ b/env.production.template
@@ -43,6 +43,7 @@ CONTACT_EMAIL_TO=hello@olgishcakes.co.uk
 CONTACT_EMAIL_BCC=backup@olgishcakes.co.uk
 ORDER_EMAIL_BCC=orders@olgishcakes.co.uk
 ADMIN_BCC_EMAIL=your_admin_email_for_bcc@example.com
+CUSTOMER_EMAIL_BCC_ENABLED=true
 
 # Supabase
 SUPABASE_URL=your_supabase_url

--- a/lib/email/__tests__/customer-bcc.test.ts
+++ b/lib/email/__tests__/customer-bcc.test.ts
@@ -1,0 +1,41 @@
+import { getCustomerEmailBcc, isCustomerEmailBccEnabled } from '../customer-bcc'
+
+describe('customer email BCC', () => {
+  const originalCustomerEmailBccEnabled = process.env.CUSTOMER_EMAIL_BCC_ENABLED
+
+  afterEach(() => {
+    if (originalCustomerEmailBccEnabled === undefined) {
+      delete process.env.CUSTOMER_EMAIL_BCC_ENABLED
+    } else {
+      process.env.CUSTOMER_EMAIL_BCC_ENABLED = originalCustomerEmailBccEnabled
+    }
+  })
+
+  it('keeps customer BCC enabled when the flag is not configured', () => {
+    delete process.env.CUSTOMER_EMAIL_BCC_ENABLED
+
+    expect(isCustomerEmailBccEnabled()).toBe(true)
+    expect(getCustomerEmailBcc(' admin@example.com ')).toBe('admin@example.com')
+  })
+
+  it.each(['false', '0', 'no', 'off', ' FALSE '])('disables customer BCC for %s', (value) => {
+    process.env.CUSTOMER_EMAIL_BCC_ENABLED = value
+
+    expect(isCustomerEmailBccEnabled()).toBe(false)
+    expect(getCustomerEmailBcc('admin@example.com')).toBeUndefined()
+  })
+
+  it('treats any other configured value as enabled', () => {
+    process.env.CUSTOMER_EMAIL_BCC_ENABLED = 'true'
+
+    expect(isCustomerEmailBccEnabled()).toBe(true)
+    expect(getCustomerEmailBcc('admin@example.com')).toBe('admin@example.com')
+  })
+
+  it('does not return an empty BCC recipient', () => {
+    process.env.CUSTOMER_EMAIL_BCC_ENABLED = 'true'
+
+    expect(getCustomerEmailBcc('  ')).toBeUndefined()
+    expect(getCustomerEmailBcc()).toBeUndefined()
+  })
+})

--- a/lib/email/__tests__/parity.test.ts
+++ b/lib/email/__tests__/parity.test.ts
@@ -36,7 +36,7 @@ describe('email render/send parity', () => {
     expect(sendResult.rendered.html).toBe(preview.html)
   })
 
-  it('embeds the customer email logo as an inline attachment', async () => {
+  it('uses the hosted customer email logo without adding an inline attachment', async () => {
     const sendResult = await sendEmail({
       templateId: 'custom-cake-enquiry-customer',
       input: {
@@ -52,13 +52,8 @@ describe('email render/send parity', () => {
     })
 
     expect(sendResult.accepted).toBe(true)
-    expect(sendResult.rendered.html).toContain('src="cid:olgish-cakes-email-logo"')
-    expect(getCapturedEmails()[0]?.message.attachments).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        filename: 'olgish-cakes-email-logo.png',
-        contentType: 'image/png',
-        contentId: 'olgish-cakes-email-logo'
-      })
-    ]))
+    expect(sendResult.rendered.html).toContain('src="https://olgishcakes.co.uk/images/olgish-cakes-email-logo.png"')
+    expect(sendResult.rendered.html).not.toContain('src="cid:olgish-cakes-email-logo"')
+    expect(getCapturedEmails()[0]?.message.attachments).toBeUndefined()
   })
 })

--- a/lib/email/__tests__/renderers.test.ts
+++ b/lib/email/__tests__/renderers.test.ts
@@ -46,14 +46,21 @@ describe('email renderers', () => {
     expect(rendered.text).toContain('Postcode: LS17 1AA')
     expect(rendered.text).toContain('Date needed: 25 May 2026')
     expect(rendered.text).toContain('Occasion: Mother\'s Day Gifts')
-    expect(rendered.text).toContain('Customer message: test requirements')
+    expect(rendered.text).toContain('Cake brief: test requirements')
+    expect(rendered.text).not.toContain('Customer message: test requirements')
     expect(rendered.text).toContain('Reference image uploaded: reference.jpg')
+    expect(rendered.text).toContain('We\'ll check the date, your notes and the delivery details.')
+    expect(rendered.text).not.toContain('We\'ll review your order and confirm all details within 24 hours')
+    expect(rendered.text).toContain('Questions about your enquiry? We\'re here to help.')
+    expect(rendered.text).not.toContain('Questions about your order? We\'re here to help.')
     expect(rendered.html).toContain('Contact details')
     expect(rendered.html).toContain('Cake details')
+    expect(rendered.html).toContain('Cake brief')
+    expect(rendered.html).not.toContain('Customer message</td>')
     expect(rendered.html).toContain('reference.jpg')
-    expect(rendered.html).toContain('src="cid:olgish-cakes-email-logo"')
+    expect(rendered.html).toContain('src="https://olgishcakes.co.uk/images/olgish-cakes-email-logo.png"')
     expect(rendered.html).toContain('width="112" height="112"')
-    expect(rendered.html).not.toContain('olgish-cakes-email-logo.png')
+    expect(rendered.html).not.toContain('src="cid:olgish-cakes-email-logo"')
     expect(rendered.html).not.toContain('olgish-cakes-logo-bakery-brand.png')
     expect(rendered.html).not.toContain('olgish-cakes-logo-bakery-brand-128.webp')
     expect(rendered.html).toContain('font-family: Inter, Arial, Helvetica, sans-serif')
@@ -61,6 +68,31 @@ describe('email renderers', () => {
     expect(rendered.html).toContain('background-color: #FFF5E6')
     expect(rendered.html).toContain('background-color: #FFFBEB')
     expect(rendered.html).toContain('background-color: #2E3192')
+  })
+
+  it('shows only the cake brief from generated quote summaries in custom enquiry customer emails', () => {
+    const rendered = renderEmailTemplate('custom-cake-enquiry-customer', {
+      orderType: 'custom-cake-enquiry',
+      customerName: 'Igor Ieromenko',
+      customerEmail: 'igor@example.com',
+      dateNeeded: '2026-07-09',
+      occasion: 'Birthday Cakes',
+      customerMessage: [
+        'Quote brief',
+        'Occasion: Birthday Cakes',
+        'Servings: 100',
+        'Brief: cake brief'
+      ].join('\n')
+    })
+
+    expect(rendered.text).toContain('Cake brief: cake brief')
+    expect(rendered.text).toContain('Servings: 100')
+    expect(rendered.text).not.toContain('Customer message:')
+    expect(rendered.text).not.toContain('Quote brief')
+    expect(rendered.text).not.toContain('Brief: cake brief')
+    expect(rendered.html).toContain('Cake brief')
+    expect(rendered.html).not.toContain('Customer message</td>')
+    expect(rendered.html).not.toContain('Quote brief')
   })
 
   it('omits empty optional fields', () => {
@@ -234,8 +266,8 @@ describe('email renderers', () => {
       dateNeeded: '2026-06-02',
       customerMessage: 'Please add candles',
       nextSteps: [
-        'I\'ll review your requested date, cake details, and any design notes within 24 hours.',
-        'I\'ll confirm availability, final price, and any design details before you need to pay.',
+        'We\'ll review your requested date, cake details, and any design notes within 24 hours.',
+        'We\'ll confirm availability, final price, and any design details before you need to pay.',
         'Nothing is booked or payable until we agree the design, price, and collection or delivery details.'
       ]
     })
@@ -246,7 +278,8 @@ describe('email renderers', () => {
     expect(rendered.text).toContain('Date needed: 2 June 2026')
     expect(rendered.text).toContain('Estimated price: £45')
     expect(rendered.text).toContain('Customer message: Please add candles')
-    expect(rendered.text).toContain('I\'ll confirm availability, final price, and any design details before you need to pay.')
+    expect(rendered.text).toContain('We\'ll confirm availability, final price, and any design details before you need to pay.')
+    expect(rendered.text).not.toContain('I\'ll')
     expect(rendered.text).toContain('Nothing is booked or payable until we agree the design, price, and collection or delivery details.')
     expect(rendered.text).not.toContain('Order Confirmation')
     expect(rendered.text).not.toContain('Total Amount')
@@ -258,6 +291,21 @@ describe('email renderers', () => {
     expect(rendered.html).toContain('Estimated price')
     expect(rendered.html).not.toContain('Order Confirmation')
     expect(rendered.html).not.toContain('Contact details')
+  })
+
+  it('renders the customer intro visibly and omits placeholder customer messages', () => {
+    const rendered = renderEmailTemplate('contact-inline-order-customer', {
+      customerName: 'Jane',
+      productName: 'Honey Cake',
+      priceLabel: 'Estimated price',
+      customerMessage: 'message',
+      intro: 'Thank you. We\'ve received your cake request and will review the details within 24 hours.'
+    })
+
+    expect(rendered.html).not.toContain('display: none')
+    expect(rendered.html).toContain('We&#39;ve received your cake request')
+    expect(rendered.text).not.toContain('Customer message: message')
+    expect(rendered.html).not.toContain('Customer message</td>')
   })
 
   it('keeps order labels for non-enquiry customer emails', () => {
@@ -320,12 +368,31 @@ describe('email renderers', () => {
       customerName: 'Jane',
       orderNumber: 'OC-TRACK-1',
       status: 'out-for-delivery',
+      deliveryCourier: 'evri',
       trackingNumber: 'TRACK-123456'
     })
 
+    expect(rendered.text).toContain('Courier: Evri')
     expect(rendered.text).toContain('Tracking number: TRACK-123456')
+    expect(rendered.text).toContain('Track your parcel: https://www.evri.com/track/parcel/TRACK-123456/details')
     expect(rendered.html).toContain('Tracking number')
     expect(rendered.html).toContain('TRACK-123456')
+    expect(rendered.html).toContain('https://www.evri.com/track/parcel/TRACK-123456/details')
+  })
+
+  it('renders Royal Mail tracking links for out-for-delivery status updates', () => {
+    const rendered = renderEmailTemplate('orders-status-update', {
+      customerName: 'Jane',
+      orderNumber: 'OC-TRACK-ROYAL-MAIL',
+      status: 'out-for-delivery',
+      deliveryCourier: 'royal-mail',
+      trackingNumber: 'RM123456789GB'
+    })
+
+    expect(rendered.text).toContain('Courier: Royal Mail')
+    expect(rendered.text).toContain('Tracking number: RM123456789GB')
+    expect(rendered.text).toContain('Track your parcel: https://www.royalmail.com/track-your-item#/tracking-results/RM123456789GB')
+    expect(rendered.html).toContain('https://www.royalmail.com/track-your-item#/tracking-results/RM123456789GB')
   })
 
   it('does not render tracking number for non-delivery statuses', () => {
@@ -444,7 +511,7 @@ describe('email renderers', () => {
       deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
       headingOverride: 'Order dispatched',
       titleOverride: 'Order Dispatched #26051220022842 - Olgish Cakes',
-      statusMessage: 'Great news, your cakes by post order has been dispatched with Royal Mail.'
+      statusMessage: 'Great news, your cake by post order has been dispatched with Royal Mail.'
     })
     const evri = renderEmailTemplate('orders-status-update', {
       customerName: 'Igor Ieromenko',
@@ -462,16 +529,19 @@ describe('email renderers', () => {
       deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
       headingOverride: 'Order dispatched',
       titleOverride: 'Order Dispatched #26051220022842 - Olgish Cakes',
-      statusMessage: 'Great news, your cakes by post order has been dispatched with Evri.'
+      statusMessage: 'Great news, your cake by post order has been dispatched with Evri.'
     })
 
     expect(royalMail.subject).toBe('Order Dispatched #26051220022842 - Olgish Cakes')
     expect(royalMail.text).toContain('Order dispatched')
+    expect(royalMail.text).toContain('Date needed: 26 May 2026')
     expect(royalMail.text).toContain('Courier: Royal Mail')
     expect(royalMail.text).toContain('Tracking number: TRACK-123456')
     expect(royalMail.text).toContain('Track your parcel: https://www.royalmail.com/track-your-item#/tracking-results/TRACK-123456')
     expect(royalMail.text).toContain('Royal Mail will update the tracking as your parcel moves through their network.')
+    expect(royalMail.text).not.toContain('Date needed: 26/05/2026')
     expect(royalMail.html).toContain('https://www.royalmail.com/track-your-item#/tracking-results/TRACK-123456')
+    expect(royalMail.html).toContain('Track your parcel')
     expect(royalMail.text.match(/Tracking number/g)).toHaveLength(1)
     expect(royalMail.text).not.toContain('Customer Notes')
     expect(royalMail.text).not.toContain('Gift Details')
@@ -497,12 +567,119 @@ describe('email renderers', () => {
       deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
       headingOverride: 'Order dispatched',
       titleOverride: 'Order Dispatched #26051220022842 - Olgish Cakes',
-      statusMessage: 'Great news, your cakes by post order has been dispatched with Evri.'
+      statusMessage: 'Great news, your cake by post order has been dispatched with Evri.'
     })
 
     expect(rendered.text).toContain('Courier: Evri')
     expect(rendered.text).toContain('Track your parcel: https://www.evri.com/track/parcel/H02X8A0022918652/details')
     expect(rendered.text).toContain('Evri will update the tracking as your parcel moves through their network.')
+  })
+
+  it('hides generated product summary from custom cake status customer messages', () => {
+    const generatedSummary = [
+      'Product: Vintage Red Velvet Cake',
+      'Product type: cake',
+      'Design type: standard',
+      'Filling: Red Velvet',
+      'Serves 8-12 people',
+      'Price: \u00A338'
+    ].join('\n')
+    const rendered = renderEmailTemplate('orders-status-update', {
+      customerName: 'Igor Ieromenko',
+      orderNumber: '26060623195079',
+      productName: 'Vintage Red Velvet Cake',
+      productType: 'cake',
+      totalPrice: 38,
+      dateNeeded: '2026-07-11',
+      status: 'out-for-delivery',
+      deliveryMethod: 'local-delivery',
+      designType: 'standard',
+      filling: 'Red Velvet',
+      servings: 'Serves 8-12 people',
+      customerMessage: generatedSummary,
+      headingOverride: 'Order out for delivery',
+      titleOverride: 'Order Out for Delivery #26060623195079 - Olgish Cakes',
+      statusMessage: 'Great news! Your order is on its way to you.'
+    })
+
+    expect(rendered.text).not.toContain('Customer message:')
+    expect(rendered.html).not.toContain('Customer message</td>')
+    expect(rendered.text).not.toContain('Product type: cake')
+    expect(rendered.html).not.toContain('Product type: cake')
+    expect(rendered.text).not.toContain('Price: \u00A338')
+  })
+
+  it('keeps postal custom cake status updates out of the cakes by post layout', () => {
+    const rendered = renderEmailTemplate('orders-status-update', {
+      customerName: 'Igor Ieromenko',
+      orderNumber: '26060623310313',
+      productName: 'Vintage Red Velvet Cake',
+      productType: 'cake',
+      totalPrice: 38,
+      status: 'out-for-delivery',
+      deliveryMethod: 'postal',
+      deliveryCourier: 'royal-mail',
+      trackingNumber: '12345',
+      deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
+      headingOverride: 'Order out for delivery',
+      titleOverride: 'Order Out for Delivery #26060623310313 - Olgish Cakes',
+      statusMessage: 'Great news, your cake order has been dispatched with Royal Mail.'
+    })
+
+    expect(rendered.subject).toBe('Order Out for Delivery #26060623310313 - Olgish Cakes')
+    expect(rendered.text).toContain('Order out for delivery')
+    expect(rendered.text).toContain('Great news, your cake order has been dispatched with Royal Mail.')
+    expect(rendered.text).toContain('Track your parcel: https://www.royalmail.com/track-your-item#/tracking-results/12345')
+    expect(rendered.text).not.toContain('Great news, your cake by post order')
+    expect(rendered.text).not.toContain('Delivery Details')
+  })
+
+  it('keeps delivered postal custom cake updates out of the cakes by post layout', () => {
+    const rendered = renderEmailTemplate('orders-status-update', {
+      customerName: 'Igor Ieromenko',
+      orderNumber: '26060623310313',
+      productName: 'Vintage Red Velvet Cake',
+      productType: 'cake',
+      totalPrice: 38,
+      status: 'delivered',
+      deliveryMethod: 'postal',
+      deliveryCourier: 'royal-mail',
+      trackingNumber: '12345',
+      deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
+      headingOverride: 'Order delivered',
+      titleOverride: 'Order Delivered #26060623310313 - Olgish Cakes',
+      statusMessage: 'Your order has been delivered. We hope you enjoy your cake.'
+    })
+
+    expect(rendered.subject).toBe('Order Delivered #26060623310313 - Olgish Cakes')
+    expect(rendered.text).toContain('Order delivered')
+    expect(rendered.text).toContain('Your order has been delivered. We hope you enjoy your cake.')
+    expect(rendered.text).not.toContain('cakes by post order')
+    expect(rendered.text).not.toContain('cake by post order')
+    expect(rendered.text).not.toContain('Delivery Details')
+  })
+
+  it('uses cake layout when stale cakes-by-post order type has cake product type', () => {
+    const rendered = renderEmailTemplate('orders-status-update', {
+      customerName: 'Igor Ieromenko',
+      orderNumber: '26060501382235',
+      orderType: 'cakes-by-post',
+      productName: 'Vintage Red Velvet Cake',
+      productType: 'cake',
+      totalPrice: 38,
+      status: 'delivered',
+      deliveryMethod: 'postal',
+      deliveryCourier: 'evri',
+      trackingNumber: '12345',
+      deliveryAddress: '15 Allerton Grange Avenue, Leeds, LS17 6PR',
+      headingOverride: 'Order delivered',
+      titleOverride: 'Order Delivered #26060501382235 - Olgish Cakes',
+      statusMessage: 'Your order has been delivered. We hope you enjoy your cake.'
+    })
+
+    expect(rendered.text).toContain('Your order has been delivered. We hope you enjoy your cake.')
+    expect(rendered.text).not.toContain('cakes by post order')
+    expect(rendered.text).not.toContain('Delivery Details')
   })
 
   it('renders concise cakes by post delivered updates with courier tracking and support next step', () => {
@@ -702,16 +879,22 @@ describe('email renderers', () => {
     expect(rendered.html).toContain('Napoleon Slice')
   })
 
-  it('renders multiple order items in status updates for text and html', () => {
+  it('omits technical order item rows in customer status updates', () => {
     const rendered = renderEmailTemplate('orders-status-update', {
       customerName: 'Jane',
       orderNumber: 'OC-MULTI-STATUS',
+      productName: 'Honey Cake',
+      dateNeeded: '2026-07-10',
+      designType: 'standard',
       status: 'confirmed',
       orderItems: [
         {
           productName: 'Honey Cake',
           quantity: 2,
           totalPrice: 40,
+          productType: 'cake',
+          productId: 'honey-cake',
+          designType: 'standard',
           specialInstructions: 'No nuts'
         },
         {
@@ -722,13 +905,17 @@ describe('email renderers', () => {
       ]
     })
 
-    expect(rendered.text).toContain('Order items')
-    expect(rendered.text).toContain('Honey Cake (Qty: 2) - \u00A340')
-    expect(rendered.text).toContain('Napoleon Slice (Qty: 1) - \u00A315')
-    expect(rendered.text).toContain('Customer message / requirements: No nuts')
-    expect(rendered.html).toContain('Order items')
-    expect(rendered.html).toContain('Honey Cake')
-    expect(rendered.html).toContain('Napoleon Slice')
+    expect(rendered.text).toContain('Order Summary')
+    expect(rendered.text).toContain('Product: Honey Cake')
+    expect(rendered.text).toContain('Date needed: 10 July 2026')
+    expect(rendered.text).toContain('Design type: Standard')
+    expect(rendered.text).not.toContain('Order items')
+    expect(rendered.text).not.toContain('Product ID')
+    expect(rendered.text).not.toContain('Type: cake')
+    expect(rendered.text).not.toContain('Honey Cake (Qty: 2)')
+    expect(rendered.html).not.toContain('Order items')
+    expect(rendered.html).not.toContain('Product ID')
+    expect(rendered.html).not.toContain('Type: cake')
   })
 })
 

--- a/lib/email/customer-bcc.ts
+++ b/lib/email/customer-bcc.ts
@@ -1,0 +1,23 @@
+const disabledCustomerBccValues = new Set(['false', '0', 'no', 'off'])
+
+export function isCustomerEmailBccEnabled(): boolean {
+  const configuredValue = process.env.CUSTOMER_EMAIL_BCC_ENABLED?.trim().toLowerCase()
+  if (!configuredValue) {
+    return true
+  }
+
+  return !disabledCustomerBccValues.has(configuredValue)
+}
+
+export function getCustomerEmailBcc(configuredBcc?: string): string | undefined {
+  if (!isCustomerEmailBccEnabled()) {
+    return undefined
+  }
+
+  const resolvedBcc = configuredBcc?.trim()
+  if (!resolvedBcc || resolvedBcc.length === 0) {
+    return undefined
+  }
+
+  return resolvedBcc
+}

--- a/lib/email/dev-input.ts
+++ b/lib/email/dev-input.ts
@@ -94,8 +94,8 @@ function withDerivedCakesByPostCourierMessage(input: UnknownRecord): UnknownReco
   return {
     ...input,
     statusMessage: input.trackingNumber
-      ? `Great news, your cakes by post order has been dispatched with ${courierLabel}.`
-      : `Great news, your cakes by post order has been dispatched with ${courierLabel} and is on the way.`
+      ? `Great news, your cake by post order has been dispatched with ${courierLabel}.`
+      : `Great news, your cake by post order has been dispatched with ${courierLabel} and is on the way.`
   }
 }
 

--- a/lib/email/templates/cakes-by-post-admin.ts
+++ b/lib/email/templates/cakes-by-post-admin.ts
@@ -1,5 +1,5 @@
 import type { EmailTemplateCommonInput } from '../types'
-import { isCakesByPostOrderLike } from '@/lib/order-types'
+import { isCakesByPostOrderType, isCakesByPostProductType } from '@/lib/order-types'
 import {
   formatCurrency,
   formatDate,
@@ -11,11 +11,13 @@ import {
 } from './shared'
 
 function isCakesByPostAdminEmail(input: EmailTemplateCommonInput): boolean {
-  return isCakesByPostOrderLike({
-    orderType: input.orderType,
-    productType: input.productType,
-    deliveryMethod: input.deliveryMethod
-  })
+  const productType = toTrimmed(input.productType)
+
+  if (productType.length > 0) {
+    return isCakesByPostProductType(productType)
+  }
+
+  return isCakesByPostOrderType(input.orderType)
 }
 
 function row(rows: CustomerRow[], label: string, value: string | null | undefined) {

--- a/lib/email/templates/cakes-by-post-customer.ts
+++ b/lib/email/templates/cakes-by-post-customer.ts
@@ -1,5 +1,5 @@
 import type { EmailTemplateCommonInput } from '../types'
-import { isCakesByPostOrderLike } from '@/lib/order-types'
+import { isCakesByPostOrderType, isCakesByPostProductType } from '@/lib/order-types'
 import {
   buildCompletedReviewHtml,
   buildCompletedReviewText,
@@ -8,7 +8,7 @@ import {
   EMAIL_FONT_SANS,
   escapeHtml,
   formatCurrency,
-  formatDate,
+  formatLongDate,
   formatPhoneDisplay,
   renderCustomerCard,
   renderEmailSpacer,
@@ -39,11 +39,13 @@ const deliveryCourierMeta: Record<DeliveryCourier, DeliveryCourierMeta> = {
 }
 
 export function isCakesByPostCustomerEmail(input: EmailTemplateCommonInput): boolean {
-  return isCakesByPostOrderLike({
-    orderType: input.orderType,
-    productType: input.productType,
-    deliveryMethod: input.deliveryMethod
-  })
+  const productType = toTrimmed(input.productType)
+
+  if (productType.length > 0) {
+    return isCakesByPostProductType(productType)
+  }
+
+  return isCakesByPostOrderType(input.orderType)
 }
 
 function cakesByPostNextSteps(): string[] {
@@ -70,6 +72,15 @@ function linkedRow(rows: CustomerRow[], label: string, value: string | null | un
   }
 
   rows.push({ label, value: trimmed, href })
+}
+
+function trackingLinkRow(rows: CustomerRow[], value: string | null | undefined, href: string | undefined) {
+  const trimmedValue = toTrimmed(value)
+  if (trimmedValue.length === 0 || !href) {
+    return
+  }
+
+  rows.push({ label: 'Tracking link', value: 'Track your parcel', href })
 }
 
 function getCourierMeta(value: string | null | undefined): DeliveryCourierMeta {
@@ -124,7 +135,7 @@ function buildDeliveryRows(input: EmailTemplateCommonInput): CustomerRow[] {
     row(rows, 'Town or city', input.city)
     row(rows, 'Postcode', input.postcode)
   }
-  row(rows, 'Date needed', formatDate(input.dateNeeded))
+  row(rows, 'Date needed', formatLongDate(input.dateNeeded))
 
   return rows
 }
@@ -175,6 +186,10 @@ function renderRowsText(title: string, rows: CustomerRow[]): string {
   }
 
   const lines = rows.flatMap((entry) => {
+    if (entry.label === 'Tracking link' && entry.href) {
+      return [`- Track your parcel: ${entry.href}`]
+    }
+
     const rowLines = [`- ${entry.label}: ${entry.value}`]
 
     if (entry.href) {
@@ -208,7 +223,7 @@ function buildStatusDeliveryRows(input: EmailTemplateCommonInput): CustomerRow[]
 
   row(rows, 'Delivery method', formatDeliveryMethod(input.deliveryMethod))
   row(rows, 'Recipient', input.deliveryRecipientName || input.customerName)
-  row(rows, 'Date needed', formatDate(input.dateNeeded))
+  row(rows, 'Date needed', formatLongDate(input.dateNeeded))
   if (courierValue.length > 0 || trackingNumber.length > 0 || normalizedStatus === 'out-for-delivery') {
     row(rows, 'Courier', courier.label)
   }
@@ -217,8 +232,9 @@ function buildStatusDeliveryRows(input: EmailTemplateCommonInput): CustomerRow[]
     rows,
     'Tracking number',
     trackingNumber,
-    trackingNumber ? courier.trackingUrl(trackingNumber) : undefined
+    undefined
   )
+  trackingLinkRow(rows, trackingNumber, trackingNumber ? courier.trackingUrl(trackingNumber) : undefined)
 
   return rows
 }

--- a/lib/email/templates/contact.ts
+++ b/lib/email/templates/contact.ts
@@ -1,7 +1,16 @@
 import type { EmailTemplateCommonInput, TemplateDefinition } from '../types'
 import { buildCakesByPostAdminContent } from './cakes-by-post-admin'
 import { buildCakesByPostCustomerContent } from './cakes-by-post-customer'
-import { createDefaultScenarioInput, createTemplateDefinition } from './shared'
+import {
+  createDefaultScenarioInput,
+  createTemplateDefinition,
+  EMAIL_FONT_SANS,
+  escapeHtml,
+  formatLongDate,
+  renderCustomerCard,
+  type CustomerEmailContent,
+  type CustomerRow
+} from './shared'
 
 const cakesByPostBaseInput = createDefaultScenarioInput({
   customerName: 'Igor Ieromenko',
@@ -102,8 +111,8 @@ const cakeProductCustomDesignInput = createDefaultScenarioInput({
 })
 
 const cakeRequestNextSteps = [
-  'I\'ll review your requested date, cake details, and any design notes within 24 hours.',
-  'I\'ll confirm availability, final price, and any design details before you need to pay.',
+  'We\'ll review your requested date, cake details, and any design notes within 24 hours.',
+  'We\'ll confirm availability, final price, and any design details before you need to pay.',
   'Nothing is booked or payable until we agree the design, price, and collection or delivery details.'
 ]
 
@@ -149,6 +158,109 @@ const adminInquiryScenarios = [
     }
   }
 ]
+
+const customerConfirmationScenarios = [
+  {
+    id: 'default',
+    label: 'General contact customer confirmation',
+    input: createDefaultScenarioInput({
+      orderNumber: undefined,
+      orderType: 'custom-cake-enquiry',
+      productName: undefined,
+      productId: undefined,
+      productType: undefined,
+      quantity: undefined,
+      unitPrice: undefined,
+      totalPrice: undefined,
+      status: undefined,
+      customerMessage: 'Can you help with a cake order?',
+      nextSteps: [
+        'We\'ll read your message and check the details you sent.',
+        'We\'ll reply with the next practical step as soon as we can.'
+      ]
+    })
+  },
+  {
+    id: 'minimal',
+    label: 'General contact customer confirmation - minimal',
+    input: {
+      customerName: 'Test Customer',
+      customerEmail: 'test@example.com',
+      customerMessage: 'Can you help with a cake order?'
+    }
+  }
+]
+
+function withColon(label: string) {
+  return `${label}:`
+}
+
+function addCustomerContactRow(rows: CustomerRow[], label: string, value: string | null | undefined) {
+  const trimmedValue = value?.trim()
+  if (!trimmedValue) {
+    return
+  }
+
+  rows.push({ label: withColon(label), value: trimmedValue })
+}
+
+function renderContactCustomerRowsText(rows: CustomerRow[]) {
+  return rows
+    .map((entry) => `- ${entry.label.replace(/:$/, '')}: ${entry.value}`)
+    .join('\n')
+}
+
+function renderContactCustomerFooterHtml() {
+  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="border-top: 1px solid #D8D9F3;"><tr><td align="center" style="padding: 20px 0 0 0; text-align: center;"><p style="margin: 0 0 10px 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 14px; line-height: 22px;">Questions about your enquiry? We're here to help.</p><p style="margin: 0; color: #2E3192; font-family: ${EMAIL_FONT_SANS}; font-size: 14px; font-weight: 700; line-height: 24px;">${escapeHtml('hello@olgishcakes.co.uk')}<br>${escapeHtml('+44 7867 218194')}</p></td></tr></table>`
+}
+
+function renderContactCustomerConfirmation(input: EmailTemplateCommonInput): CustomerEmailContent {
+  const contactRows: CustomerRow[] = []
+  const enquiryRows: CustomerRow[] = []
+  const nextSteps = input.nextSteps && input.nextSteps.length > 0
+    ? input.nextSteps
+    : [
+        'We\'ll read your message and check the details you sent.',
+        'We\'ll reply with the next practical step as soon as we can.'
+      ]
+
+  addCustomerContactRow(contactRows, 'Name', input.customerName)
+  addCustomerContactRow(contactRows, 'Email', input.customerEmail)
+  addCustomerContactRow(contactRows, 'Phone', input.customerPhone)
+  addCustomerContactRow(enquiryRows, 'Address', input.address)
+  addCustomerContactRow(enquiryRows, 'City', input.city)
+  addCustomerContactRow(enquiryRows, 'Postcode', input.postcode)
+  addCustomerContactRow(enquiryRows, 'Topic', input.cakeInterest)
+  addCustomerContactRow(enquiryRows, 'Date', formatLongDate(input.dateNeeded))
+  addCustomerContactRow(enquiryRows, 'Message', input.customerMessage || input.message)
+  addCustomerContactRow(enquiryRows, 'Additional note', input.note)
+  addCustomerContactRow(enquiryRows, 'Gift note', input.giftNote)
+  addCustomerContactRow(enquiryRows, 'Attachments', input.attachmentNames?.join(', '))
+
+  const nextStepsText = `What happens next\n${nextSteps.map((step) => `- ${step}`).join('\n')}`
+  const nextStepsHtml = renderCustomerCard(
+    'What happens next',
+    nextSteps.map((step, index) => ({ label: `Step ${index + 1}:`, value: step }))
+  )
+
+  return {
+    bodyText: [
+      contactRows.length > 0
+        ? `Contact details\n${renderContactCustomerRowsText(contactRows)}`
+        : '',
+      enquiryRows.length > 0
+        ? `Your message\n${renderContactCustomerRowsText(enquiryRows)}`
+        : '',
+      nextStepsText,
+    ].filter((section) => section.length > 0).join('\n\n'),
+    bodyHtml: [
+      renderCustomerCard('Contact details', contactRows),
+      renderCustomerCard('Your message', enquiryRows),
+      nextStepsHtml,
+      renderContactCustomerFooterHtml()
+    ].join('')
+  }
+}
 
 const inlineOrderCustomerScenarios = [
   {
@@ -255,6 +367,18 @@ export const contactTemplateDefinitions: Record<string, TemplateDefinition<Email
       admin: true
     },
     adminInquiryScenarios
+  ),
+  'contact-customer-confirmation': createTemplateDefinition(
+    {
+      subject: 'We have received your message',
+      heading: 'Thank you for contacting Olgish Cakes',
+      intro: 'Thank you, we\'ve received your message and we\'ll get back to you as soon as we can.',
+      admin: false
+    },
+    customerConfirmationScenarios,
+    {
+      customerContentBuilder: renderContactCustomerConfirmation
+    }
   ),
   'contact-inline-order-customer': createTemplateDefinition(
     {

--- a/lib/email/templates/custom-cake-enquiry.ts
+++ b/lib/email/templates/custom-cake-enquiry.ts
@@ -111,8 +111,8 @@ const customerScenarios = [
       giftNote: undefined,
       attachmentNames: ['floral-cake-reference.jpg'],
       nextSteps: [
-        'I\'ll check the date, your notes and the delivery details.',
-        'I\'ll reply with availability, any questions, and a quote if I can make it for that date.',
+        'We\'ll check the date, your notes and the delivery details.',
+        'We\'ll reply with availability, any questions, and a quote if we can make it for that date.',
         'Nothing is booked or payable until we agree the design, price and collection or delivery details.'
       ]
     })
@@ -129,8 +129,8 @@ const customerScenarios = [
       customerMessage: 'Need a custom cake with floral style.',
       message: 'Date needed: 20/06/2026',
       nextSteps: [
-        'I\'ll check the date, your notes and the delivery details.',
-        'I\'ll reply with availability, any questions, and a quote if I can make it for that date.',
+        'We\'ll check the date, your notes and the delivery details.',
+        'We\'ll reply with availability, any questions, and a quote if we can make it for that date.',
         'Nothing is booked or payable until we agree the design, price and collection or delivery details.'
       ]
     }
@@ -169,8 +169,8 @@ const customerScenarios = [
       giftNote: undefined,
       attachmentNames: ['wedding-cake-reference.jpg'],
       nextSteps: [
-        'I\'ll check the date, your notes and the delivery details.',
-        'I\'ll reply with availability, any questions, and a quote if I can make it for that date.',
+        'We\'ll check the date, your notes and the delivery details.',
+        'We\'ll reply with availability, any questions, and a quote if we can make it for that date.',
         'Nothing is booked or payable until we agree the design, price and collection or delivery details.'
       ]
     })
@@ -187,8 +187,8 @@ const customerScenarios = [
       customerMessage: 'Please quote for a two-tier cake.',
       message: 'Date needed: 05/07/2026',
       nextSteps: [
-        'I\'ll check the date, your notes and the delivery details.',
-        'I\'ll reply with availability, any questions, and a quote if I can make it for that date.',
+        'We\'ll check the date, your notes and the delivery details.',
+        'We\'ll reply with availability, any questions, and a quote if we can make it for that date.',
         'Nothing is booked or payable until we agree the design, price and collection or delivery details.'
       ]
     }

--- a/lib/email/templates/orders.ts
+++ b/lib/email/templates/orders.ts
@@ -103,7 +103,7 @@ const statusUpdateScenarios = [
       status: 'out-for-delivery',
       titleOverride: 'Order Dispatched #26051220022842 - Olgish Cakes',
       headingOverride: 'Order dispatched',
-      statusMessage: 'Great news, your cakes by post order has been dispatched with Evri.',
+      statusMessage: 'Great news, your cake by post order has been dispatched with Evri.',
       deliveryCourier: 'evri',
       trackingNumber: 'TRACK-123456'
     }

--- a/lib/email/templates/shared.ts
+++ b/lib/email/templates/shared.ts
@@ -42,7 +42,7 @@ export function formatDate(value: string | null | undefined): string {
   return parsed.toLocaleDateString('en-GB')
 }
 
-function formatLongDate(value: string | null | undefined): string {
+export function formatLongDate(value: string | null | undefined): string {
   const raw = toTrimmed(value)
   if (raw.length === 0) {
     return ''
@@ -67,6 +67,33 @@ export function formatCurrency(value: number | null | undefined): string {
   }
 
   return `\u00A3${value}`
+}
+
+function formatDisplayLabel(value: string | null | undefined): string {
+  const trimmedValue = toTrimmed(value)
+  if (trimmedValue.length === 0 || /[A-Z]/.test(trimmedValue)) {
+    return trimmedValue
+  }
+
+  return trimmedValue
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b[a-z]/g, (letter) => letter.toUpperCase())
+}
+
+function getTrackingMeta(value: string | null | undefined): { label: string, url: (trackingNumber: string) => string } {
+  const normalizedValue = toTrimmed(value).toLowerCase()
+
+  if (normalizedValue === 'royal-mail') {
+    return {
+      label: 'Royal Mail',
+      url: (trackingNumber) => `https://www.royalmail.com/track-your-item#/tracking-results/${encodeURIComponent(trackingNumber)}`
+    }
+  }
+
+  return {
+    label: 'Evri',
+    url: (trackingNumber) => `https://www.evri.com/track/parcel/${encodeURIComponent(trackingNumber)}/details`
+  }
 }
 
 export function formatPhoneDisplay(value: string | null | undefined): string {
@@ -238,6 +265,28 @@ function renderOrderItemText(item: NormalizedOrderItem): string {
   return lines.join('\n')
 }
 
+function renderCustomerOrderItemText(item: NormalizedOrderItem): string {
+  const lines = [formatOrderItemSummary(item)]
+
+  if (item.designType.length > 0) {
+    lines.push(`Design type: ${formatDisplayLabel(item.designType)}`)
+  }
+
+  if (item.servings.length > 0) {
+    lines.push(`Servings: ${item.servings}`)
+  }
+
+  if (item.filling.length > 0) {
+    lines.push(`Filling: ${item.filling}`)
+  }
+
+  if (item.specialInstructions.length > 0) {
+    lines.push(`Customer message / requirements: ${item.specialInstructions}`)
+  }
+
+  return lines.join('\n')
+}
+
 export function renderOrderItemsText(items: NormalizedOrderItem[]): string {
   return items
     .map((item, index) => {
@@ -269,6 +318,40 @@ export function renderOrderItemsHtml(items: NormalizedOrderItem[]): string {
 
     if (item.designType.length > 0) {
       details.push(`Design type: ${item.designType}`)
+    }
+
+    if (item.servings.length > 0) {
+      details.push(`Servings: ${item.servings}`)
+    }
+
+    if (item.filling.length > 0) {
+      details.push(`Filling: ${item.filling}`)
+    }
+
+    if (item.specialInstructions.length > 0) {
+      details.push(`Customer message / requirements: ${item.specialInstructions}`)
+    }
+
+    const detailsHtml = details.length > 0
+      ? `<ul style="margin: 8px 0 0 18px; padding: 0; color: #4B5563; font-family: ${EMAIL_FONT_SANS}; font-size: 14px; line-height: 21px;">${details.map((detail) => `<li>${escapeHtml(detail)}</li>`).join('')}</ul>`
+      : ''
+
+    return `<li style="margin: 0 0 12px 0;"><p style="margin: 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 15px; line-height: 23px;">${escapeHtml(formatOrderItemSummary(item))}</p>${detailsHtml}</li>`
+  }).join('')
+
+  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" bgcolor="#ffffff" style="background-color: #ffffff; border: 1px solid #D8D9F3; border-radius: 10px; border-collapse: separate;"><tr><td style="padding: 22px 24px;"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td style="padding: 0 0 14px 0; color: #2E3192; font-family: ${EMAIL_FONT_DISPLAY}; font-size: 16px; font-weight: 700; line-height: 22px; text-transform: uppercase;">Order items</td></tr></table><ol style="margin: 0; padding-left: 18px;">${itemRows}</ol></td></tr></table>${renderEmailSpacer(14)}`
+}
+
+function renderCustomerOrderItemsHtml(items: NormalizedOrderItem[]): string {
+  if (items.length === 0) {
+    return ''
+  }
+
+  const itemRows = items.map((item) => {
+    const details: string[] = []
+
+    if (item.designType.length > 0) {
+      details.push(`Design type: ${formatDisplayLabel(item.designType)}`)
     }
 
     if (item.servings.length > 0) {
@@ -477,7 +560,15 @@ function buildSubject(meta: TemplateMeta, input: EmailTemplateCommonInput): stri
   return meta.subject
 }
 
-function defaultNextSteps(): string[] {
+function defaultNextSteps(input: EmailTemplateCommonInput): string[] {
+  if (isCustomCakeEnquiry(input)) {
+    return [
+      'We\'ll check the date, your notes and the delivery details.',
+      'We\'ll reply with availability, any questions, and a quote if we can make it for that date.',
+      'Nothing is booked or payable until we agree the design, price and collection or delivery details.'
+    ]
+  }
+
   return [
     'We\'ll review your order and confirm all details within 24 hours',
     'We\'ll contact you with a quote and final design details',
@@ -494,7 +585,7 @@ function resolveNextSteps(input: EmailTemplateCommonInput): string[] {
     return []
   }
 
-  return defaultNextSteps()
+  return defaultNextSteps(input)
 }
 
 export interface CustomerRow {
@@ -510,8 +601,7 @@ interface CustomerRows {
 }
 
 const TRUSTPILOT_REVIEW_URL = 'https://uk.trustpilot.com/review/olgishcakes.co.uk'
-const EMAIL_LOGO_CID = 'olgish-cakes-email-logo'
-const EMAIL_LOGO_SRC = `cid:${EMAIL_LOGO_CID}`
+const EMAIL_HOSTED_LOGO_SRC = 'https://olgishcakes.co.uk/images/olgish-cakes-email-logo.png'
 export const EMAIL_FONT_SANS = 'Inter, Arial, Helvetica, sans-serif'
 export const EMAIL_FONT_DISPLAY = '\'More Sugar\', \'Trebuchet MS\', Arial, Helvetica, sans-serif'
 
@@ -519,8 +609,115 @@ function isCustomCakeEnquiry(input: EmailTemplateCommonInput): boolean {
   return input.orderType === 'custom-cake-enquiry'
 }
 
+function renderCustomerOrderItemsText(items: NormalizedOrderItem[]): string {
+  return items
+    .map((item, index) => {
+      const lines = renderCustomerOrderItemText(item).split('\n')
+      const [firstLine, ...extraLines] = lines
+      return [
+        `${index + 1}. ${firstLine}`,
+        ...extraLines.map((line) => `   ${line}`)
+      ].join('\n')
+    })
+    .join('\n')
+}
+
 function isCakeRequestEmail(input: EmailTemplateCommonInput): boolean {
   return isCustomCakeEnquiry(input) || toTrimmed(input.priceLabel).length > 0
+}
+
+function resolveEmailLogoSrc(): string {
+  const configuredSiteUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim()
+  if (!configuredSiteUrl) {
+    return EMAIL_HOSTED_LOGO_SRC
+  }
+
+  try {
+    const parsedSiteUrl = new URL(configuredSiteUrl)
+    if (parsedSiteUrl.protocol !== 'https:') {
+      return EMAIL_HOSTED_LOGO_SRC
+    }
+
+    return new URL('/images/olgish-cakes-email-logo.png', parsedSiteUrl).toString()
+  } catch {
+    return EMAIL_HOSTED_LOGO_SRC
+  }
+}
+
+function resolveCustomerMessage(value: string | null | undefined): string {
+  const trimmedValue = toTrimmed(value)
+  const normalizedValue = trimmedValue.toLowerCase()
+
+  if (
+    normalizedValue === 'message' ||
+    normalizedValue === 'test message' ||
+    isGeneratedProductSummary(normalizedValue)
+  ) {
+    return ''
+  }
+
+  return trimmedValue
+}
+
+function resolveCakeBrief(value: string | null | undefined): string {
+  const customerMessage = resolveCustomerMessage(value)
+  if (customerMessage.length === 0) {
+    return ''
+  }
+
+  const lines = customerMessage
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+  if (lines[0]?.toLowerCase() !== 'quote brief') {
+    return customerMessage
+  }
+
+  const briefLine = lines.find((line) => line.toLowerCase().startsWith('brief:'))
+  if (!briefLine) {
+    return ''
+  }
+
+  return briefLine.slice('Brief:'.length).trim()
+}
+
+function parseQuoteRequirementFields(value: string | null | undefined): Map<string, string> {
+  const customerMessage = resolveCustomerMessage(value)
+  const lines = customerMessage
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+  if (lines[0]?.toLowerCase() !== 'quote brief') {
+    return new Map()
+  }
+
+  return lines.slice(1).reduce<Map<string, string>>((fields, line) => {
+    const separatorIndex = line.indexOf(':')
+    if (separatorIndex <= 0) {
+      return fields
+    }
+
+    const label = line.slice(0, separatorIndex).trim()
+    const fieldValue = line.slice(separatorIndex + 1).trim()
+    if (label.length === 0 || fieldValue.length === 0) {
+      return fields
+    }
+
+    fields.set(label.toLowerCase(), fieldValue)
+    return fields
+  }, new Map())
+}
+
+function isGeneratedProductSummary(normalizedValue: string): boolean {
+  if (normalizedValue.length === 0) {
+    return false
+  }
+
+  return normalizedValue.includes('product:') &&
+    normalizedValue.includes('product type:') &&
+    normalizedValue.includes('price:')
 }
 
 function buildCustomerRows(input: EmailTemplateCommonInput): CustomerRows {
@@ -536,10 +733,23 @@ function buildCustomerRows(input: EmailTemplateCommonInput): CustomerRows {
 
     rows.push({ label, value: trimmed })
   }
+  const linkedRow = (rows: CustomerRow[], label: string, value: string | null | undefined, href: string | undefined) => {
+    const trimmed = toTrimmed(value)
+    if (trimmed.length === 0) {
+      return
+    }
+
+    rows.push({ label, value: trimmed, href })
+  }
 
   const customCakeEnquiry = isCustomCakeEnquiry(input)
+  const quoteFields = customCakeEnquiry
+    ? parseQuoteRequirementFields(input.customerMessage)
+    : new Map<string, string>()
   const priceLabel = toTrimmed(input.priceLabel) || 'Total Amount'
-  const dateNeeded = isCakeRequestEmail(input) ? formatLongDate(input.dateNeeded) : formatDate(input.dateNeeded)
+  const dateNeeded = isCakeRequestEmail(input) || toTrimmed(input.status).length > 0
+    ? formatLongDate(input.dateNeeded)
+    : formatDate(input.dateNeeded)
 
   if (customCakeEnquiry) {
     row(contactRows, 'Name', input.customerName)
@@ -557,14 +767,39 @@ function buildCustomerRows(input: EmailTemplateCommonInput): CustomerRows {
 
   const normalizedStatus = toTrimmed(input.status).toLowerCase()
   if (normalizedStatus === 'out-for-delivery' || normalizedStatus === 'out-delivery') {
-    row(summaryRows, 'Tracking number', input.trackingNumber)
+    const trackingNumber = toTrimmed(input.trackingNumber)
+    const trackingMeta = getTrackingMeta(input.deliveryCourier)
+
+    if (trackingNumber.length > 0) {
+      row(summaryRows, 'Courier', trackingMeta.label)
+    }
+
+    linkedRow(
+      summaryRows,
+      'Tracking number',
+      trackingNumber,
+      trackingNumber ? trackingMeta.url(trackingNumber) : undefined
+    )
   }
 
-  row(preferencesRows, 'Occasion', input.occasion)
-  row(preferencesRows, 'Design type', input.designType)
+  row(preferencesRows, 'Occasion', formatDisplayLabel(input.occasion) || quoteFields.get('occasion'))
+  row(preferencesRows, 'Design type', formatDisplayLabel(input.designType))
   row(preferencesRows, 'Filling', input.filling)
-  row(preferencesRows, 'Servings', input.servings)
-  row(preferencesRows, 'Customer message', input.customerMessage)
+  row(preferencesRows, 'Servings', input.servings || quoteFields.get('servings'))
+  row(
+    preferencesRows,
+    customCakeEnquiry ? 'Cake brief' : 'Customer message',
+    customCakeEnquiry
+      ? quoteFields.get('brief') || resolveCakeBrief(input.customerMessage)
+      : resolveCustomerMessage(input.customerMessage)
+  )
+  quoteFields.forEach((fieldValue, fieldKey) => {
+    if (['occasion', 'servings', 'brief'].includes(fieldKey)) {
+      return
+    }
+
+    row(preferencesRows, formatDisplayLabel(fieldKey), fieldValue)
+  })
   row(preferencesRows, 'Gift note', input.giftNote)
   if (customCakeEnquiry && Array.isArray(input.attachmentNames)) {
     row(preferencesRows, 'Reference image uploaded', input.attachmentNames.join(', '))
@@ -597,16 +832,24 @@ function buildCustomerTextBody(input: EmailTemplateCommonInput, nextSteps: strin
   const rows = buildCustomerRows(input)
   const normalizedOrderItems = normalizeOrderItems(input)
   const customCakeEnquiry = isCustomCakeEnquiry(input)
+  const isStatusUpdate = toTrimmed(input.status).length > 0
   const summaryTitle = customCakeEnquiry ? 'Enquiry Summary' : 'Order Summary'
   const preferencesTitle = customCakeEnquiry ? 'Cake Details' : 'Order Preferences'
   const contact = rows.contact.length > 0
     ? `Contact Details\n${rows.contact.map((entry) => `- ${entry.label}: ${entry.value}`).join('\n')}`
     : ''
   const summary = rows.summary.length > 0
-    ? `${summaryTitle}\n${rows.summary.map((entry) => `- ${entry.label}: ${entry.value}`).join('\n')}`
+    ? `${summaryTitle}\n${rows.summary.flatMap((entry) => {
+        const rowLines = [`- ${entry.label}: ${entry.value}`]
+        if (entry.href) {
+          rowLines.push(`- Track your parcel: ${entry.href}`)
+        }
+
+        return rowLines
+      }).join('\n')}`
     : ''
-  const orderItemsSection = normalizedOrderItems.length > 0
-    ? `Order items\n${renderOrderItemsText(normalizedOrderItems)}`
+  const orderItemsSection = normalizedOrderItems.length > 0 && !isStatusUpdate
+    ? `Order items\n${renderCustomerOrderItemsText(normalizedOrderItems)}`
     : ''
   const preferences = rows.preferences.length > 0
     ? `${preferencesTitle}\n${rows.preferences.map((entry) => `- ${entry.label}: ${entry.value}`).join('\n')}`
@@ -625,9 +868,13 @@ function buildCustomerTextBody(input: EmailTemplateCommonInput, nextSteps: strin
     .filter((section) => section.length > 0)
     .join('\n\n')
 }
-export function buildCustomerFooterText(): string {
+function getCustomerFooterQuestion(input?: EmailTemplateCommonInput): string {
+  return isCustomCakeEnquiry(input ?? {}) ? 'Questions about your enquiry?' : 'Questions about your order?'
+}
+
+export function buildCustomerFooterText(input?: EmailTemplateCommonInput): string {
   return [
-    'Questions about your order? We\'re here to help.',
+    `${getCustomerFooterQuestion(input)} We're here to help.`,
     'hello@olgishcakes.co.uk',
     '+44 7867 218194'
   ].join('\n')
@@ -656,16 +903,18 @@ export function renderCustomerCard(title: string, rows: CustomerRow[]): string {
   return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" bgcolor="#ffffff" style="background-color: #ffffff; border: 1px solid #D8D9F3; border-radius: 10px; border-collapse: separate;"><tr><td style="padding: 22px 24px;"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td style="padding: 0 0 14px 0; color: #2E3192; font-family: ${EMAIL_FONT_DISPLAY}; font-size: 16px; font-weight: 700; line-height: 22px; text-transform: uppercase;">${escapeHtml(title)}</td></tr></table><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">${tableRows}</table></td></tr></table>${renderEmailSpacer(14)}`
 }
 
-export function buildCustomerFooterHtml(): string {
-  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="border-top: 1px solid #D8D9F3;"><tr><td align="center" style="padding: 20px 0 0 0; text-align: center;"><p style="margin: 0 0 10px 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 14px; line-height: 22px;">Questions about your order? We're here to help.</p><p style="margin: 0; font-family: ${EMAIL_FONT_SANS}; font-size: 14px; line-height: 24px;"><a href="mailto:hello@olgishcakes.co.uk" style="color: #2E3192; text-decoration: none; font-weight: 700;">hello@olgishcakes.co.uk</a><br><a href="tel:+447867218194" style="color: #2E3192; text-decoration: none; font-weight: 700;">+44 7867 218194</a></p></td></tr></table>`
+export function buildCustomerFooterHtml(input?: EmailTemplateCommonInput): string {
+  const question = escapeHtml(getCustomerFooterQuestion(input))
+  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="border-top: 1px solid #D8D9F3;"><tr><td align="center" style="padding: 20px 0 0 0; text-align: center;"><p style="margin: 0 0 10px 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 14px; line-height: 22px;">${question} We're here to help.</p><p style="margin: 0; font-family: ${EMAIL_FONT_SANS}; font-size: 14px; line-height: 24px;"><a href="mailto:hello@olgishcakes.co.uk" style="color: #2E3192; text-decoration: none; font-weight: 700;">hello@olgishcakes.co.uk</a><br><a href="tel:+447867218194" style="color: #2E3192; text-decoration: none; font-weight: 700;">+44 7867 218194</a></p></td></tr></table>`
 }
 
 function buildCustomerHtmlBody(input: EmailTemplateCommonInput, nextSteps: string[]): string {
   const rows = buildCustomerRows(input)
   const customCakeEnquiry = isCustomCakeEnquiry(input)
+  const isStatusUpdate = toTrimmed(input.status).length > 0
   const contactCard = renderCustomerCard('Contact details', rows.contact)
   const summaryCard = renderCustomerCard(customCakeEnquiry ? 'Enquiry summary' : 'Order Summary', rows.summary)
-  const orderItemsCard = renderOrderItemsHtml(normalizeOrderItems(input))
+  const orderItemsCard = isStatusUpdate ? '' : renderCustomerOrderItemsHtml(normalizeOrderItems(input))
   const preferencesCard = renderCustomerCard(customCakeEnquiry ? 'Cake details' : 'Order Preferences', rows.preferences)
 
   const steps = nextSteps.length > 0
@@ -676,7 +925,7 @@ function buildCustomerHtmlBody(input: EmailTemplateCommonInput, nextSteps: strin
     ? buildCompletedReviewHtml()
     : ''
 
-  return `${contactCard}${summaryCard}${orderItemsCard}${preferencesCard}${steps}${completedReviewCard}${buildCustomerFooterHtml()}`
+  return `${contactCard}${summaryCard}${orderItemsCard}${preferencesCard}${steps}${completedReviewCard}${buildCustomerFooterHtml(input)}`
 }
 function buildTemplateEmail(meta: TemplateMeta, input: EmailTemplateCommonInput, options: TemplateOptions = {}): RenderedEmail {
   const subject = buildSubject(meta, input)
@@ -696,7 +945,7 @@ function buildTemplateEmail(meta: TemplateMeta, input: EmailTemplateCommonInput,
 
   const greetingName = input.customerName?.trim() || 'there'
   const greetingPrefix = meta.admin ? 'Hello' : 'Dear'
-  const signature = meta.admin ? 'Olgish Cakes' : buildCustomerFooterText()
+  const signature = meta.admin ? 'Olgish Cakes' : buildCustomerFooterText(input)
 
   const text = [
     heading,
@@ -713,7 +962,8 @@ function buildTemplateEmail(meta: TemplateMeta, input: EmailTemplateCommonInput,
   const htmlSignature = meta.admin
     ? '<p style="margin: 24px 0 0 0; color: #374151; font-size: 14px;">Olgish Cakes</p>'
     : ''
-  const html = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${escapeHtml(subject)}</title></head><body bgcolor="#FFF5E6" style="margin: 0; padding: 0; background-color: #FFF5E6; font-family: ${EMAIL_FONT_SANS};"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" bgcolor="#FFF5E6" style="background-color: #FFF5E6; border-collapse: collapse;"><tr><td align="center" style="padding: 28px 14px;"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" bgcolor="#FFFBEB" style="width: 100%; max-width: 600px; background-color: #FFFBEB; border: 1px solid #D8D9F3; border-radius: 10px; border-collapse: separate;"><tr><td align="center" bgcolor="#2E3192" style="background-color: #2E3192; padding: 24px 24px 22px 24px; text-align: center;"><img src="${EMAIL_LOGO_SRC}" alt="Olgish Cakes" width="112" height="112" style="display: block; width: 112px; height: 112px; margin: 0 auto 16px auto; border: 0; outline: none; text-decoration: none;"><h1 style="margin: 0; color: #ffffff; font-family: ${EMAIL_FONT_DISPLAY}; font-size: 25px; font-weight: 700; line-height: 32px; letter-spacing: 0;">${escapeHtml(heading)}</h1></td></tr><tr><td bgcolor="#FFFBEB" style="background-color: #FFFBEB; padding: 30px 28px;"><p style="margin: 0 0 16px 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 16px; line-height: 26px;">${greetingPrefix} <strong>${escapeHtml(greetingName)}</strong>,</p><p style="margin: 0 0 24px 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 16px; line-height: 27px;">${escapeHtml(intro)}</p>${bodyHtml}${htmlSignature}</td></tr></table></td></tr></table></body></html>`
+  const logoSrc = resolveEmailLogoSrc()
+  const html = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${escapeHtml(subject)}</title></head><body bgcolor="#FFF5E6" style="margin: 0; padding: 0; background-color: #FFF5E6; font-family: ${EMAIL_FONT_SANS};"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" bgcolor="#FFF5E6" style="background-color: #FFF5E6; border-collapse: collapse;"><tr><td align="center" style="padding: 28px 14px;"><table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" bgcolor="#FFFBEB" style="width: 100%; max-width: 600px; background-color: #FFFBEB; border: 1px solid #D8D9F3; border-radius: 10px; border-collapse: separate;"><tr><td align="center" bgcolor="#2E3192" style="background-color: #2E3192; padding: 24px 24px 22px 24px; text-align: center;"><img src="${logoSrc}" alt="Olgish Cakes" width="112" height="112" style="display: block; width: 112px; height: 112px; margin: 0 auto 16px auto; border: 0; outline: none; text-decoration: none;"><h1 style="margin: 0; color: #ffffff; font-family: ${EMAIL_FONT_DISPLAY}; font-size: 25px; font-weight: 700; line-height: 32px; letter-spacing: 0;">${escapeHtml(heading)}</h1></td></tr><tr><td bgcolor="#FFFBEB" style="background-color: #FFFBEB; padding: 30px 28px;"><p style="margin: 0 0 16px 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 16px; line-height: 26px;">${greetingPrefix} <strong>${escapeHtml(greetingName)}</strong>,</p><p style="margin: 0 0 24px 0; color: #1F2937; font-family: ${EMAIL_FONT_SANS}; font-size: 16px; line-height: 27px;">${escapeHtml(intro)}</p>${bodyHtml}${htmlSignature}</td></tr></table></td></tr></table></body></html>`
 
   return {
     subject,

--- a/lib/email/templates/workshop-enquiry.ts
+++ b/lib/email/templates/workshop-enquiry.ts
@@ -65,7 +65,7 @@ export const workshopTemplateDefinitions: Record<string, TemplateDefinition<Emai
     {
       subject: 'Workshop enquiry received',
       heading: 'Workshop enquiry received',
-      intro: 'Thank you for your workshop enquiry. I will review the details and come back to you shortly.',
+      intro: 'Thank you for your workshop enquiry. We will review the details and come back to you shortly.',
       admin: false
     },
     customerScenarios

--- a/lib/email/types.ts
+++ b/lib/email/types.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod'
 
 export const emailTemplateIds = [
   'contact-admin-inquiry',
+  'contact-customer-confirmation',
   'contact-inline-order-customer',
   'contact-inline-order-admin',
   'contact-inline-order-fallback-customer',
@@ -91,6 +92,7 @@ export interface EmailTemplateCommonInput {
 }
 
 export type ContactAdminInquiryInput = EmailTemplateCommonInput
+export type ContactCustomerConfirmationInput = EmailTemplateCommonInput
 export type ContactInlineOrderCustomerInput = EmailTemplateCommonInput
 export type ContactInlineOrderAdminInput = EmailTemplateCommonInput
 export type ContactInlineOrderFallbackCustomerInput = EmailTemplateCommonInput
@@ -109,6 +111,7 @@ export type InstagramTokenRefreshAlertInput = EmailTemplateCommonInput
 
 export type EmailRenderInputMap = {
   'contact-admin-inquiry': ContactAdminInquiryInput
+  'contact-customer-confirmation': ContactCustomerConfirmationInput
   'contact-inline-order-customer': ContactInlineOrderCustomerInput
   'contact-inline-order-admin': ContactInlineOrderAdminInput
   'contact-inline-order-fallback-customer': ContactInlineOrderFallbackCustomerInput


### PR DESCRIPTION
- Introduced `isCustomerEmailBccEnabled` and `getCustomerEmailBcc` functions to manage BCC settings for customer emails.
- Updated email templates for cakes by post to use singular "cake" instead of plural "cakes" for consistency.
- Refactored `isCakesByPostAdminEmail` and `isCakesByPostCustomerEmail` functions to utilize new product type checks.
- Enhanced the contact email template to include a new customer confirmation scenario with structured contact details.
- Modified custom cake enquiry templates to use "we" instead of "I" for a more collaborative tone.
- Improved order status update messages to include tracking links and courier information.
- Added new utility functions for rendering customer order details and handling customer messages.
- Updated footer text in email templates to reflect the context of customer inquiries.